### PR TITLE
Restyle UI to match GenomicX front-end style guide

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,43 +5,48 @@ import ThemeToggle from '@/components/ThemeToggle';
 
 export default function AboutPage() {
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
-      {/* Header */}
-      <header className="bg-gradient-to-r from-blue-600 to-blue-700 dark:from-blue-700 dark:to-blue-800 text-white shadow-lg sticky top-0 z-40">
+    <div className="min-h-screen flex flex-col" style={{ background: 'var(--gx-bg)' }}>
+      {/* Navigation - Frosted Glass */}
+      <nav className="sticky top-0 z-40" style={{ background: 'var(--gx-nav-bg)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', borderBottom: '1px solid var(--gx-border)' }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <Link href="/" className="flex items-center space-x-3 hover:opacity-90 transition-opacity">
-              <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <circle cx="12" cy="12" r="10" strokeWidth="2" />
-                <circle cx="12" cy="12" r="6" strokeWidth="2" />
-                <circle cx="12" cy="12" r="2" strokeWidth="2" />
+          <div className="flex items-center justify-between h-[60px]">
+            <Link href="/" className="flex items-center gap-3 hover:opacity-90 transition-opacity">
+              <svg className="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="var(--gx-accent)" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <circle cx="12" cy="12" r="6" />
+                <circle cx="12" cy="12" r="2" />
               </svg>
               <div>
-                <h1 className="text-xl font-bold">BRIGX</h1>
-                <p className="text-xs text-blue-100">BLAST Ring Image Generator</p>
+                <h1 className="text-lg font-bold" style={{ color: 'var(--gx-text-bright)' }}>BRIGX</h1>
+                <p className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>BLAST Ring Image Generator</p>
               </div>
             </Link>
-            <ThemeToggle />
+            <div className="flex items-center gap-4">
+              <Link href="/" className="text-sm font-medium transition-colors hover:text-[var(--gx-accent)]" style={{ color: 'var(--gx-text-muted)' }}>
+                App
+              </Link>
+              <ThemeToggle />
+            </div>
           </div>
         </div>
-      </header>
+      </nav>
 
       {/* Main Content */}
       <main className="flex-grow py-12">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="card">
-            <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-8">About BRIGX</h1>
-            
-            <div className="prose dark:prose-invert max-w-none">
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-6 mb-4">Overview</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
-                BRIGX (BLAST Ring Image Generator eXtended) is a web-based tool for comparative genomics visualization. 
-                It creates circular genome comparison plots similar to the original BRIG tool, but runs entirely in your browser 
+            <h1 className="text-4xl font-bold mb-8" style={{ color: 'var(--gx-text-bright)', letterSpacing: '-0.025em' }}>About BRIGX</h1>
+
+            <div className="max-w-none">
+              <h2 className="text-2xl font-semibold mt-6 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Overview</h2>
+              <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
+                BRIGX (BLAST Ring Image Generator eXtended) is a web-based tool for comparative genomics visualization.
+                It creates circular genome comparison plots similar to the original BRIG tool, but runs entirely in your browser
                 using WebAssembly technology.
               </p>
 
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Features</h2>
-              <ul className="list-disc pl-6 text-gray-700 dark:text-gray-300 space-y-2 mb-4">
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Features</h2>
+              <ul className="list-disc pl-6 space-y-2 mb-4" style={{ color: 'var(--gx-text)' }}>
                 <li>Compare multiple genome sequences against a reference genome</li>
                 <li>Interactive circular visualization with multiple rings</li>
                 <li>GC content and GC skew analysis</li>
@@ -51,45 +56,46 @@ export default function AboutPage() {
                 <li>All processing happens locally in your browser</li>
               </ul>
 
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">How It Works</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
-                BRIGX uses LASTZ, a powerful DNA sequence alignment tool, compiled to WebAssembly. This allows 
-                sophisticated bioinformatics analysis to run directly in your web browser without requiring any 
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>How It Works</h2>
+              <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
+                BRIGX uses LASTZ, a powerful DNA sequence alignment tool, compiled to WebAssembly. This allows
+                sophisticated bioinformatics analysis to run directly in your web browser without requiring any
                 server-side processing or data upload.
               </p>
 
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Privacy</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
-                All processing happens locally in your browser using WebAssembly. Your genome data never leaves 
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Privacy</h2>
+              <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
+                All processing happens locally in your browser using WebAssembly. Your genome data never leaves
                 your computer, ensuring complete privacy and security of your research data.
               </p>
 
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Technology Stack</h2>
-              <ul className="list-disc pl-6 text-gray-700 dark:text-gray-300 space-y-2 mb-4">
-                <li><strong>LASTZ:</strong> DNA sequence alignment tool (v1.04.52)</li>
-                <li><strong>WebAssembly:</strong> High-performance browser execution</li>
-                <li><strong>Next.js:</strong> React framework for the user interface</li>
-                <li><strong>Web Workers:</strong> Parallel processing for faster alignments</li>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Technology Stack</h2>
+              <ul className="list-disc pl-6 space-y-2 mb-4" style={{ color: 'var(--gx-text)' }}>
+                <li><strong style={{ color: 'var(--gx-text-bright)' }}>LASTZ:</strong> DNA sequence alignment tool (v1.04.52)</li>
+                <li><strong style={{ color: 'var(--gx-text-bright)' }}>WebAssembly:</strong> High-performance browser execution</li>
+                <li><strong style={{ color: 'var(--gx-text-bright)' }}>Next.js:</strong> React framework for the user interface</li>
+                <li><strong style={{ color: 'var(--gx-text-bright)' }}>Web Workers:</strong> Parallel processing for faster alignments</li>
               </ul>
 
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Citation</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Citation</h2>
+              <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 If you use BRIGX in your research, please cite the original BRIG paper:
               </p>
-              <blockquote className="border-l-4 border-blue-500 pl-4 italic text-gray-600 dark:text-gray-400 mb-4">
-                Alikhan NF, Petty NK, Ben Zakour NL, Beatson SA (2011) BLAST Ring Image Generator (BRIG): 
+              <blockquote className="pl-4 italic mb-4" style={{ borderLeft: '4px solid var(--gx-accent)', color: 'var(--gx-text-muted)' }}>
+                Alikhan NF, Petty NK, Ben Zakour NL, Beatson SA (2011) BLAST Ring Image Generator (BRIG):
                 simple prokaryote genome comparisons. BMC Genomics 12:402.
               </blockquote>
 
-              <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Contributing</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Contributing</h2>
+              <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 BRIGX is an open-source project. You can edit this page and contribute to the project on GitHub.
               </p>
 
-              <div className="mt-8 pt-8 border-t border-gray-200 dark:border-gray-700">
-                <Link 
+              <div className="mt-8 pt-8" style={{ borderTop: '1px solid var(--gx-border)' }}>
+                <Link
                   href="/"
-                  className="inline-flex items-center text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
+                  className="inline-flex items-center font-medium transition-colors"
+                  style={{ color: 'var(--gx-accent)' }}
                 >
                   <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
@@ -103,17 +109,17 @@ export default function AboutPage() {
       </main>
 
       {/* Footer */}
-      <footer className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 py-8 mt-auto">
+      <footer className="mt-auto py-8" style={{ background: 'var(--gx-bg-alt)', borderTop: '1px solid var(--gx-border)' }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="text-gray-600 dark:text-gray-400 text-sm mb-4 md:mb-0">
-              © 2026 BRIGX. Built with Next.js and WebAssembly.
+            <div className="text-sm mb-4 md:mb-0" style={{ color: 'var(--gx-text-muted)' }}>
+              BRIGX. Built with Next.js and WebAssembly.
             </div>
-            <div className="flex space-x-6 text-sm">
-              <Link href="/about" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+            <div className="flex gap-6 text-sm">
+              <Link href="/about" className="transition-colors hover:text-[var(--gx-accent)]" style={{ color: 'var(--gx-text-muted)' }}>
                 About
               </Link>
-              <a href="https://github.com" target="_blank" rel="noopener noreferrer" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+              <a href="https://github.com/happykhan/brigx" target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-[var(--gx-accent)]" style={{ color: 'var(--gx-text-muted)' }}>
                 GitHub
               </a>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,66 +1,177 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ── GenomicX Design Tokens ── */
+:root {
+  /* Dark theme (default) */
+  --gx-bg: #0F172A;
+  --gx-bg-alt: #1E293B;
+  --gx-bg-elevated: #253349;
+  --gx-text: #E2E8F0;
+  --gx-text-muted: #94A3B8;
+  --gx-text-bright: #F1F5F9;
+  --gx-border: #334155;
+  --gx-accent: #14B8A6;
+  --gx-accent-hover: #2DD4BF;
+  --gx-accent-dim: rgba(20, 184, 166, 0.1);
+  --gx-accent-15: rgba(20, 184, 166, 0.15);
+  --gx-indigo: #6366F1;
+  --gx-indigo-dim: rgba(99, 102, 241, 0.1);
+  --gx-success: #14B8A6;
+  --gx-warning: #F59E0B;
+  --gx-error: #EF4444;
+  --gx-nav-bg: rgba(15, 23, 42, 0.9);
+  --gx-code-bg: #0F172A;
+  --gx-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --gx-transition: 0.2s ease;
+  --gx-radius: 8px;
+  --gx-radius-lg: 12px;
+}
+
+[data-theme="light"] {
+  --gx-bg: #FFFFFF;
+  --gx-bg-alt: #F8FAFC;
+  --gx-bg-elevated: #F1F5F9;
+  --gx-text: #334155;
+  --gx-text-muted: #64748B;
+  --gx-text-bright: #0F172A;
+  --gx-border: #E2E8F0;
+  --gx-nav-bg: rgba(255, 255, 255, 0.9);
+  --gx-code-bg: #F1F5F9;
+  --gx-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
 
 @layer base {
   html {
     @apply antialiased;
   }
-  
+
   body {
-    @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background-color: var(--gx-bg);
+    color: var(--gx-text);
+    line-height: 1.7;
+    transition: background-color var(--gx-transition), color var(--gx-transition);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    margin: 0;
   }
-  
+
   * {
-    @apply transition-colors duration-200;
+    transition: background-color var(--gx-transition), border-color var(--gx-transition), color var(--gx-transition);
+  }
+
+  code {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
   }
 }
 
 @layer components {
   .card {
-    @apply bg-white dark:bg-gray-800 rounded-xl shadow-md dark:shadow-xl border border-gray-200 dark:border-gray-700 p-6;
+    background: var(--gx-bg-alt);
+    border: 1px solid var(--gx-border);
+    border-radius: var(--gx-radius-lg);
+    padding: 1.5rem;
+    transition: border-color var(--gx-transition);
   }
-  
+
+  .card:hover {
+    border-color: var(--gx-accent);
+  }
+
   .btn-primary {
-    @apply bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white font-medium px-4 py-2 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: var(--gx-accent);
+    color: #0F172A;
+    font-weight: 600;
+    font-size: 0.875rem;
+    padding: 0.7rem 1.4rem;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    transition: all var(--gx-transition);
   }
-  
+
+  .btn-primary:hover {
+    background: var(--gx-accent-hover);
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   .btn-secondary {
-    @apply bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-medium px-4 py-2 rounded-lg shadow-sm hover:shadow-md transition-all duration-200;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: transparent;
+    color: var(--gx-text);
+    font-weight: 600;
+    font-size: 0.875rem;
+    padding: 0.7rem 1.4rem;
+    border-radius: 6px;
+    border: 1px solid var(--gx-border);
+    cursor: pointer;
+    transition: all var(--gx-transition);
   }
-  
+
+  .btn-secondary:hover {
+    border-color: var(--gx-accent);
+    color: var(--gx-accent);
+  }
+
   .input-field {
-    @apply bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-transparent;
+    background: var(--gx-bg);
+    border: 1px solid var(--gx-border);
+    color: var(--gx-text);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    transition: border-color var(--gx-transition);
+    outline: none;
   }
-  
+
+  .input-field:focus {
+    border-color: var(--gx-accent);
+  }
+
   .label {
-    @apply block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2;
+    display: block;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--gx-text-bright);
+    margin-bottom: 0.5rem;
   }
-  
+
   .section-title {
-    @apply text-xl font-bold text-gray-900 dark:text-gray-100 mb-4;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--gx-text-bright);
+    margin-bottom: 1rem;
+    letter-spacing: -0.01em;
   }
-  
+
   .progress-bar {
-    @apply bg-blue-600 dark:bg-blue-500 h-2 rounded-full transition-all duration-300;
+    background: var(--gx-accent);
+    height: 6px;
+    border-radius: 999px;
+    transition: width 0.3s ease;
   }
-  
+
   .progress-bg {
-    @apply bg-gray-200 dark:bg-gray-700 h-2 rounded-full overflow-hidden;
+    background: var(--gx-bg);
+    height: 6px;
+    border-radius: 999px;
+    overflow: hidden;
   }
-}
-
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 /* Smooth scrolling */
@@ -75,13 +186,14 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-gray-100 dark:bg-gray-800;
+  background: var(--gx-bg);
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-gray-300 dark:bg-gray-600 rounded-full;
+  background: var(--gx-border);
+  border-radius: 999px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-gray-400 dark:bg-gray-500;
+  background: var(--gx-text-muted);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 import './globals.css'
-import ThemeToggle from '@/components/ThemeToggle'
 
 export const metadata: Metadata = {
   title: 'BRIGX - Browser-Based Ring Image Generator',
@@ -13,9 +12,19 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="h-full">
+    <html lang="en" className="h-full" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: `
+          (function() {
+            var theme = localStorage.getItem('gx-theme');
+            if (!theme) {
+              theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+            }
+            document.documentElement.setAttribute('data-theme', theme);
+          })();
+        `}} />
+      </head>
       <body className="h-full">
-        <ThemeToggle />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,13 +11,14 @@ import ExportPanel from '@/components/ExportPanel';
 import ConsoleLog from '@/components/ConsoleLog';
 import ImageProperties, { type ImagePropertiesConfig } from '@/components/ImageProperties';
 import AnnotationEditor from '@/components/AnnotationEditor';
+import ThemeToggle from '@/components/ThemeToggle';
 import type { CircularPlotData, PipelineParams, ProgressUpdate, RingConfig, Annotation } from '@/lib/types';
 import type { BRIGController as BRIGControllerType } from '@/lib/controller';
 
 export default function Home() {
   const [referenceFile, setReferenceFile] = useState<File | null>(null);
   const [rings, setRings] = useState<RingConfig[]>([]);
-  
+
   // Store controller instance in ref to persist alignment cache across runs
   const controllerRef = useRef<BRIGControllerType | null>(null);
   const [params, setParams] = useState<PipelineParams>({
@@ -44,7 +45,7 @@ export default function Home() {
     labelFontSize: 14,
     title: ''
   });
-  
+
   // Annotation editor state
   const [annotationEditorOpen, setAnnotationEditorOpen] = useState(false);
   const [editingRingId, setEditingRingId] = useState<string | null>(null);
@@ -74,7 +75,7 @@ export default function Home() {
     };
 
     console.error = (...args: any[]) => {
-      const message = args.map(arg => 
+      const message = args.map(arg =>
         typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)
       ).join(' ');
       setConsoleLogs(prev => [...prev, `[ERROR] ${message}`]);
@@ -82,7 +83,7 @@ export default function Home() {
     };
 
     console.warn = (...args: any[]) => {
-      const message = args.map(arg => 
+      const message = args.map(arg =>
         typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)
       ).join(' ');
       setConsoleLogs(prev => [...prev, `[WARN] ${message}`]);
@@ -102,7 +103,7 @@ export default function Home() {
       ...prev,
       [ringId]: annotations
     }));
-    
+
     // Update plot data if it exists
     if (cachedPlotData && cachedPlotData.rings) {
       const updatedRings = cachedPlotData.rings.map(ringData => {
@@ -120,13 +121,13 @@ export default function Home() {
         }
         return ringData;
       });
-      
+
       const updatedPlotData = {
         reference: cachedPlotData.reference,
         rings: updatedRings,
         config: cachedPlotData.config
       };
-      
+
       setPlotData(updatedPlotData);
       setCachedPlotData(updatedPlotData);
     }
@@ -151,7 +152,7 @@ export default function Home() {
       const { BRIGController } = await import('@/lib/controller');
       const controller = new BRIGController();
       await controller.initialize();
-      
+
       // Run pipeline without any ring files to just get reference data (GC content/skew)
       const skeletonResult = await controller.runFullPipeline(
         referenceFile!,
@@ -160,7 +161,7 @@ export default function Home() {
         params,
         (update) => setProgress(update)
       );
-      
+
       // Create ring placeholders for configured rings
       const ringPlaceholders = rings.map((ringConfig) => ({
         queryId: ringConfig.id,
@@ -177,12 +178,12 @@ export default function Home() {
           totalAlignedBases: 0
         }
       }));
-      
+
       const plotDataWithRings = {
         ...skeletonResult,
         rings: ringPlaceholders
       };
-      
+
       setPlotData(plotDataWithRings);
       setCachedPlotData(plotDataWithRings);
       setReferenceLength(skeletonResult.reference.length);
@@ -196,16 +197,16 @@ export default function Home() {
   // NOTE: This should NOT depend on cachedPlotData to avoid overwriting alignment results
   useEffect(() => {
     if (!cachedPlotData) return;
-    
+
     console.log('[Page] Ring settings changed, updating plot');
-    
+
     // Create a map of existing ring data by queryId
     const ringDataMap = new Map((cachedPlotData.rings || []).map(r => [r.queryId, r]));
-    
+
     // Update all configured rings, whether they have alignment data or not
     const updatedRings = rings.map((ringConfig) => {
       const existingRingData = ringDataMap.get(ringConfig.id);
-      
+
       if (existingRingData) {
         // Ring has alignment data - update it
         return {
@@ -235,7 +236,7 @@ export default function Home() {
         };
       }
     });
-    
+
     setPlotData({
       ...cachedPlotData,
       rings: updatedRings
@@ -244,15 +245,15 @@ export default function Home() {
 
   const handleRun = async () => {
     console.log('[Page] === Generate Plot (Run Alignments) clicked ===');
-    
+
     // Clear console logs on each run
     setConsoleLogs([]);
-    
+
     if (!referenceFile) {
       toast.error('Please select a reference genome');
       return;
     }
-    
+
     // Check if there are any rings with files to align
     const ringsWithFiles = rings.filter(r => r.files.length > 0);
     if (ringsWithFiles.length === 0) {
@@ -275,9 +276,9 @@ export default function Home() {
       } else {
         console.log('[Page] Reusing existing BRIGController instance (cache preserved)');
       }
-      
+
       const controller = controllerRef.current;
-      
+
       const result = await controller.runFullPipeline(
         referenceFile,
         ringsWithFiles,
@@ -286,14 +287,14 @@ export default function Home() {
         (update) => {
           console.log('[Page] Progress update:', update);
           setProgress(update);
-          
+
           // Update plot immediately as each ring completes
           if (update.partialData?.rings && update.partialData.rings.length > 0) {
             console.log('[Page] Received partial data with', update.partialData.rings.length, 'rings');
-            
+
             // Merge new ring data with existing cached data (preserve all rings and annotations)
             const hasExistingRings = cachedPlotData?.rings && cachedPlotData.rings.length > 0;
-            
+
             let mergedRings;
             if (hasExistingRings) {
               // Start with all existing rings
@@ -313,7 +314,7 @@ export default function Home() {
                 }
                 return existingRing;
               });
-              
+
               // Add any new rings that weren't in the cache
               const newRingsToAdd = update.partialData!.rings!.filter(
                 newRing => !cachedPlotData.rings.some(existing => existing.queryName === newRing.queryName)
@@ -347,27 +348,27 @@ export default function Home() {
                 };
               });
             }
-            
+
             const updatedPlotData = {
               reference: update.partialData.reference || cachedPlotData?.reference!,
               rings: mergedRings,
               config: update.partialData.config || cachedPlotData?.config!
             };
-            
+
             setPlotData(updatedPlotData);
           }
         }
       );
-      
+
       console.log('[Page] Alignments complete! Merging results...');
       console.log('[Page] Result rings:', result.rings?.map(r => r.queryName).join(', '));
       console.log('[Page] Cached plot data:', cachedPlotData);
       console.log('[Page] Existing rings:', cachedPlotData?.rings?.map(r => ({ name: r.queryName, annotations: r.annotations?.length || 0 })));
-      
+
       // Merge final alignment results into existing plot data
       // CRITICAL: Check if existing rings array has any items, not just if it exists
       const hasExistingRings = cachedPlotData?.rings && cachedPlotData.rings.length > 0;
-      
+
       const finalRings = hasExistingRings
         ? cachedPlotData.rings.map(existingRing => {
             const newRingData = result.rings?.find(r => r.queryName === existingRing.queryName);
@@ -391,16 +392,16 @@ export default function Home() {
             // Add annotations from ringAnnotations state if they exist
             annotations: ring.annotations || ringAnnotations[ring.queryId] || []
           })) || []; // Use alignment results directly with annotations from state if no existing rings
-      
+
       console.log('[Page] Final rings after merge:', finalRings?.map(r => ({ name: r.queryName, hits: r.hits?.length || 0, annotations: r.annotations?.length || 0 })));
-      
+
       // Keep existing skeleton (reference, GC data), only update rings with alignment data
       if (cachedPlotData) {
         const finalPlotData = {
           ...cachedPlotData,
           rings: finalRings
         };
-        
+
         console.log('[Page] Setting final plot data with rings:', finalPlotData.rings?.length);
         setPlotData(finalPlotData);
         setCachedPlotData(finalPlotData);
@@ -423,14 +424,18 @@ export default function Home() {
 
   return (
     <>
-      <Toaster 
+      <Toaster
         position="bottom-right"
         toastOptions={{
-          className: 'dark:bg-gray-800 dark:text-white',
+          style: {
+            background: 'var(--gx-bg-alt)',
+            color: 'var(--gx-text)',
+            border: '1px solid var(--gx-border)',
+          },
           success: {
             duration: 3000,
             iconTheme: {
-              primary: '#10b981',
+              primary: '#14B8A6',
               secondary: '#fff',
             },
           },
@@ -443,237 +448,238 @@ export default function Home() {
           },
         }}
       />
-      <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
-        {/* Header */}
-        <header className="bg-gradient-to-r from-blue-600 to-blue-700 dark:from-blue-700 dark:to-blue-800 text-white shadow-lg sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center">
-              <svg className="w-8 h-8 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <circle cx="12" cy="12" r="9" strokeWidth="2" />
-                <circle cx="12" cy="12" r="5" strokeWidth="2" />
-                <circle cx="12" cy="12" r="1" strokeWidth="2" fill="currentColor" />
-              </svg>
-              <div>
-                <h1 className="text-2xl font-bold">BRIGX</h1>
-                <p className="text-xs text-blue-100 dark:text-blue-200">Browser-based Ring Image Generator</p>
+      <div className="min-h-screen flex flex-col" style={{ background: 'var(--gx-bg)' }}>
+        {/* Navigation - Frosted Glass */}
+        <nav className="sticky top-0 z-40" style={{ background: 'var(--gx-nav-bg)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', borderBottom: '1px solid var(--gx-border)' }}>
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center justify-between h-[60px]">
+              <div className="flex items-center gap-3">
+                {/* DNA Rings Icon */}
+                <svg className="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="var(--gx-accent)" strokeWidth="2">
+                  <circle cx="12" cy="12" r="9" />
+                  <circle cx="12" cy="12" r="5" />
+                  <circle cx="12" cy="12" r="1" fill="var(--gx-accent)" />
+                </svg>
+                <div>
+                  <h1 className="text-lg font-bold" style={{ color: 'var(--gx-text-bright)' }}>BRIGX</h1>
+                  <p className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>Browser-based Ring Image Generator</p>
+                </div>
+              </div>
+              <div className="hidden md:flex items-center gap-6">
+                <Link href="/about" className="text-sm font-medium hover:text-gx-accent transition-colors" style={{ color: 'var(--gx-text-muted)' }}>
+                  About
+                </Link>
+                <a href="https://github.com/happykhan/brigx" target="_blank" rel="noopener" className="text-sm font-medium hover:text-gx-accent transition-colors" style={{ color: 'var(--gx-text-muted)' }}>
+                  GitHub
+                </a>
+                <ThemeToggle />
               </div>
             </div>
-            <nav className="hidden md:flex space-x-6">
-              <button className="text-blue-100 hover:text-white transition-colors">Documentation</button>
-              <Link href="/about" className="text-blue-100 hover:text-white transition-colors">
-                About
-              </Link>
-              <a href="https://github.com" target="_blank" rel="noopener" className="text-blue-100 hover:text-white transition-colors">
-                GitHub
-              </a>
-            </nav>
           </div>
-        </div>
-      </header>
+        </nav>
 
-      {/* Main Content */}
-      <main className="flex-1 py-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Info Banner */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
-            {/* Left Sidebar - Input Panel */}
-            <div className="lg:col-span-1 space-y-6 animate-fade-in">
-              <div className="card">
-                <h2 className="section-title">Reference Genome</h2>
-                <div>
-                  <label className="label">Reference Genome (FASTA)</label>
-                  <input
-                    type="file"
-                    accept=".fasta,.fa,.fna,.gbk,.gb"
-                    onChange={(e) => {
-                      if (e.target.files && e.target.files[0]) {
-                        setReferenceFile(e.target.files[0]);
-                      }
-                    }}
-                    className="input-field w-full text-sm"
+        {/* Main Content */}
+        <main className="flex-1 py-8">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+              {/* Left Sidebar - Input Panel */}
+              <div className="lg:col-span-1 space-y-6 animate-fade-in">
+                <div className="card">
+                  <h2 className="section-title">Reference Genome</h2>
+                  <div>
+                    <label className="label">Reference Genome (FASTA)</label>
+                    <input
+                      type="file"
+                      accept=".fasta,.fa,.fna,.gbk,.gb"
+                      onChange={(e) => {
+                        if (e.target.files && e.target.files[0]) {
+                          setReferenceFile(e.target.files[0]);
+                        }
+                      }}
+                      className="input-field w-full text-sm file:mr-3 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-xs file:font-semibold file:cursor-pointer"
+                      style={{ fontSize: '0.8rem' }}
+                    />
+                    {referenceFile && (
+                      <div className="mt-2 flex items-center text-sm" style={{ color: 'var(--gx-accent)' }}>
+                        <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                        </svg>
+                        {referenceFile.name}
+                      </div>
+                    )}
+                    <p className="text-xs mt-2" style={{ color: 'var(--gx-text-muted)' }}>
+                      Must contain exactly ONE sequence
+                    </p>
+                  </div>
+                </div>
+
+                <div className="card">
+                  <RingConfiguration
+                    rings={rings}
+                    setRings={setRings}
+                    onEditAnnotations={handleOpenAnnotationEditor}
                   />
-                  {referenceFile && (
-                    <div className="mt-2 flex items-center text-sm text-green-600 dark:text-green-400">
-                      <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                </div>
+
+                <div className="card">
+                  <h2 className="section-title">Parameters</h2>
+                  <ParameterControls
+                    params={params}
+                    setParams={setParams}
+                    disabled={isProcessing}
+                  />
+                </div>
+
+                <button
+                  onClick={handleRun}
+                  disabled={isProcessing || !referenceFile || rings.filter(r => r.files.length > 0).length === 0}
+                  className="w-full btn-primary py-3 px-6 text-lg font-semibold"
+                >
+                  {isProcessing ? (
+                    <span className="flex items-center justify-center">
+                      <svg className="animate-spin -ml-1 mr-3 h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
-                      {referenceFile.name}
+                      Running Alignments...
+                    </span>
+                  ) : (
+                    'Run Alignments'
+                  )}
+                </button>
+              </div>
+
+              {/* Visualization Panel */}
+              <div className="lg:col-span-2 animate-slide-up">
+                {/* Image Properties */}
+                <div className="mb-6 animate-fade-in">
+                  <ImageProperties
+                    config={imageProperties}
+                    onChange={setImageProperties}
+                  />
+                </div>
+
+                <div className="card">
+                  <div className="flex justify-between items-center mb-6">
+                    <h2 className="section-title mb-0">Circular Plot</h2>
+                    {plotData && <ExportPanel plotData={plotData} imageProperties={imageProperties} />}
+                  </div>
+
+                  {plotData ? (
+                    <CircularPlot data={plotData} imageProperties={imageProperties} />
+                  ) : (
+                    <div className="flex items-center justify-center h-96" style={{ color: 'var(--gx-text-muted)' }}>
+                      <div className="text-center">
+                        <svg className="mx-auto h-24 w-24 mb-4 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <circle cx="12" cy="12" r="10" strokeWidth="1.5" />
+                          <circle cx="12" cy="12" r="6" strokeWidth="1.5" />
+                          <circle cx="12" cy="12" r="2" strokeWidth="1.5" />
+                        </svg>
+                        <p className="text-lg">Upload a reference genome to begin</p>
+                        <p className="text-sm mt-2">The plot will generate automatically with GC content/skew rings</p>
+                      </div>
                     </div>
                   )}
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                    Must contain exactly ONE sequence
-                  </p>
-                </div>
-              </div>
-
-              <div className="card">
-                <RingConfiguration 
-                  rings={rings} 
-                  setRings={setRings}
-                  onEditAnnotations={handleOpenAnnotationEditor}
-                />
-              </div>
-
-              <div className="card">
-                <h2 className="section-title">Parameters</h2>
-                <ParameterControls
-                  params={params}
-                  setParams={setParams}
-                  disabled={isProcessing}
-                />
-              </div>
-
-              <button
-                onClick={handleRun}
-                disabled={isProcessing || !referenceFile || rings.filter(r => r.files.length > 0).length === 0}
-                className="w-full btn-primary py-3 px-6 text-lg font-semibold"
-              >
-                {isProcessing ? (
-                  <span className="flex items-center justify-center">
-                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    Running Alignments...
-                  </span>
-                ) : (
-                  'Run Alignments'
-                )}
-              </button>
-            </div>
-
-            {/* Visualization Panel */}
-            <div className="lg:col-span-2 animate-slide-up">
-            {/* Image Properties */}
-            <div className="mb-6 animate-fade-in">
-              <ImageProperties 
-                config={imageProperties}
-                onChange={setImageProperties}
-              />
-            </div>
-
-            <div className="card">
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="section-title mb-0">Circular Plot</h2>
-                {plotData && <ExportPanel plotData={plotData} imageProperties={imageProperties} />}
-              </div>
-              
-              {plotData ? (
-                <CircularPlot data={plotData} imageProperties={imageProperties} />
-              ) : (
-                <div className="flex items-center justify-center h-96 text-gray-400 dark:text-gray-500">
-                  <div className="text-center">
-                    <svg className="mx-auto h-24 w-24 mb-4 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <circle cx="12" cy="12" r="10" strokeWidth="1.5" />
-                      <circle cx="12" cy="12" r="6" strokeWidth="1.5" />
-                      <circle cx="12" cy="12" r="2" strokeWidth="1.5" />
-                    </svg>
-                    <p className="text-lg">Upload a reference genome to begin</p>
-                    <p className="text-sm mt-2">The plot will generate automatically with GC content/skew rings</p>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Console Log */}
-            <div className="mt-6 animate-fade-in">
-              <ConsoleLog logs={consoleLogs} progress={progress} />
-            </div>
-
-            {plotData && (
-              <div className="mt-6 card animaprogress={progress} te-fade-in">
-                <h2 className="section-title">Statistics</h2>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="bg-blue-50 dark:bg-blue-900/30 p-4 rounded-lg border border-blue-100 dark:border-blue-800">
-                    <div className="text-sm text-gray-600 dark:text-gray-400">Reference</div>
-                    <div className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{plotData.reference.name}</div>
-                    <div className="text-sm text-gray-500 dark:text-gray-400">{(plotData.reference.length / 1000).toFixed(1)} kb</div>
-                  </div>
-                  <div className="bg-green-50 dark:bg-green-900/30 p-4 rounded-lg border border-green-100 dark:border-green-800">
-                    <div className="text-sm text-gray-600 dark:text-gray-400">Query Genomes</div>
-                    <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{plotData.rings?.length || 0}</div>
-                  </div>
-                  <div className="bg-purple-50 dark:bg-purple-900/30 p-4 rounded-lg border border-purple-100 dark:border-purple-800">
-                    <div className="text-sm text-gray-600 dark:text-gray-400">Window Size</div>
-                    <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{plotData.config?.windowSize || 0} bp</div>
-                  </div>
-                  <div className="bg-orange-50 dark:bg-orange-900/30 p-4 rounded-lg border border-orange-100 dark:border-orange-800">
-                    <div className="text-sm text-gray-600 dark:text-gray-400">Min Identity</div>
-                    <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{plotData.config?.minIdentity || 0}%</div>
-                  </div>
                 </div>
 
-                {plotData.rings && plotData.rings.length > 0 && (
-                <div className="mt-6">
-                  <h3 className="font-semibold mb-3 text-gray-900 dark:text-gray-100">Query Genome Coverage</h3>
-                  <div className="space-y-2">
-                    {plotData.rings.map((ring) => (
-                      <div key={ring.queryId} className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg border border-gray-100 dark:border-gray-600 hover:shadow-md transition-shadow">
-                        <div className="flex-1">
-                          <div className="font-medium text-gray-900 dark:text-gray-100">{ring.queryName}</div>
-                          <div className="text-sm text-gray-600 dark:text-gray-400">
-                            Coverage: {ring.statistics.genomeCoverage.toFixed(1)}% • 
-                            Avg Identity: {ring.statistics.meanIdentity.toFixed(1)}%
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          {ring.lastzOutput && (
-                            <button
-                              onClick={() => {
-                                const blob = new Blob([ring.lastzOutput!], { type: 'text/plain' });
-                                const url = URL.createObjectURL(blob);
-                                const a = document.createElement('a');
-                                a.href = url;
-                                a.download = `${ring.queryName}_alignment.txt`;
-                                a.click();
-                                URL.revokeObjectURL(url);
-                                toast.success(`Downloaded alignment results for ${ring.queryName}`);
-                              }}
-                              className="btn-secondary text-xs px-2 py-1 flex items-center gap-1"
-                            >
-                              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                              </svg>
-                              Download
-                            </button>
-                          )}
-                          <div 
-                            className="w-4 h-4 rounded-full ring-2 ring-gray-300 dark:ring-gray-600 flex-shrink-0" 
-                            style={{ backgroundColor: ring.color }}
-                          />
+                {/* Console Log */}
+                <div className="mt-6 animate-fade-in">
+                  <ConsoleLog logs={consoleLogs} progress={progress} />
+                </div>
+
+                {plotData && (
+                  <div className="mt-6 card animate-fade-in">
+                    <h2 className="section-title">Statistics</h2>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-accent-dim)', border: '1px solid var(--gx-border)' }}>
+                        <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Reference</div>
+                        <div className="text-base font-semibold truncate mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.reference.name}</div>
+                        <div className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>{(plotData.reference.length / 1000).toFixed(1)} kb</div>
+                      </div>
+                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-accent-dim)', border: '1px solid var(--gx-border)' }}>
+                        <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Query Genomes</div>
+                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.rings?.length || 0}</div>
+                      </div>
+                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-indigo-dim)', border: '1px solid var(--gx-border)' }}>
+                        <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Window Size</div>
+                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.config?.windowSize || 0} bp</div>
+                      </div>
+                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-indigo-dim)', border: '1px solid var(--gx-border)' }}>
+                        <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Min Identity</div>
+                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.config?.minIdentity || 0}%</div>
+                      </div>
+                    </div>
+
+                    {plotData.rings && plotData.rings.length > 0 && (
+                      <div className="mt-6">
+                        <h3 className="font-semibold mb-3" style={{ color: 'var(--gx-text-bright)' }}>Query Genome Coverage</h3>
+                        <div className="space-y-2">
+                          {plotData.rings.map((ring) => (
+                            <div key={ring.queryId} className="flex items-center justify-between p-3 rounded-lg transition-colors" style={{ background: 'var(--gx-bg-elevated)', border: '1px solid var(--gx-border)' }}>
+                              <div className="flex-1">
+                                <div className="font-medium" style={{ color: 'var(--gx-text-bright)' }}>{ring.queryName}</div>
+                                <div className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>
+                                  Coverage: {ring.statistics.genomeCoverage.toFixed(1)}% |
+                                  Avg Identity: {ring.statistics.meanIdentity.toFixed(1)}%
+                                </div>
+                              </div>
+                              <div className="flex items-center gap-3">
+                                {ring.lastzOutput && (
+                                  <button
+                                    onClick={() => {
+                                      const blob = new Blob([ring.lastzOutput!], { type: 'text/plain' });
+                                      const url = URL.createObjectURL(blob);
+                                      const a = document.createElement('a');
+                                      a.href = url;
+                                      a.download = `${ring.queryName}_alignment.txt`;
+                                      a.click();
+                                      URL.revokeObjectURL(url);
+                                      toast.success(`Downloaded alignment results for ${ring.queryName}`);
+                                    }}
+                                    className="btn-secondary text-xs px-2 py-1"
+                                  >
+                                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                    </svg>
+                                    Download
+                                  </button>
+                                )}
+                                <div
+                                  className="w-4 h-4 rounded-full flex-shrink-0"
+                                  style={{ backgroundColor: ring.color, boxShadow: `0 0 0 2px var(--gx-border)` }}
+                                />
+                              </div>
+                            </div>
+                          ))}
                         </div>
                       </div>
-                    ))}
+                    )}
                   </div>
-                </div>
                 )}
               </div>
-            )}
             </div>
           </div>
-        </div>
-      </main>
-      
-      {/* Footer */}
-      <footer className="mt-auto border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="text-sm text-gray-600 dark:text-gray-400 mb-4 md:mb-0">
-              <p className="font-semibold">BRIGX - Powered by LASTZ & WebAssembly</p>
-              <p className="mt-1">All processing runs locally in your browser - no data leaves your computer</p>
-            </div>
-            <div className="flex space-x-6 text-sm">
-              <a href="/about" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                About
-              </a>
-              <a href="https://github.com" target="_blank" rel="noopener noreferrer" className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                GitHub
-              </a>
+        </main>
+
+        {/* Footer */}
+        <footer className="mt-auto" style={{ borderTop: '1px solid var(--gx-border)', background: 'var(--gx-bg-alt)' }}>
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <div className="flex flex-col md:flex-row justify-between items-center">
+              <div className="text-sm mb-4 md:mb-0" style={{ color: 'var(--gx-text-muted)' }}>
+                <p className="font-semibold" style={{ color: 'var(--gx-text)' }}>BRIGX - Powered by LASTZ & WebAssembly</p>
+                <p className="mt-1">All processing runs locally in your browser - no data leaves your computer</p>
+              </div>
+              <div className="flex gap-6 text-sm">
+                <a href="/about" className="transition-colors hover:text-[var(--gx-accent)]" style={{ color: 'var(--gx-text-muted)' }}>
+                  About
+                </a>
+                <a href="https://github.com/happykhan/brigx" target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-[var(--gx-accent)]" style={{ color: 'var(--gx-text-muted)' }}>
+                  GitHub
+                </a>
+              </div>
             </div>
           </div>
-        </div>
-      </footer>
+        </footer>
       </div>
 
       {/* Annotation Editor Modal */}

--- a/components/AnnotationEditor.tsx
+++ b/components/AnnotationEditor.tsx
@@ -39,24 +39,24 @@ export default function AnnotationEditor({
     try {
       const content = await file.text();
       const result = parseAnnotationFile(content, referenceLength);
-      
+
       if (result.errors.length > 0) {
         toast.error(`Parsed with ${result.errors.length} warning(s)`);
         console.warn('Annotation parsing warnings:', result.errors);
       }
-      
+
       if (result.annotations.length === 0) {
         toast.error('No valid annotations found in file');
         return;
       }
-      
+
       setLocalAnnotations([...localAnnotations, ...result.annotations]);
       toast.success(`Loaded ${result.annotations.length} annotation(s)`);
     } catch (error) {
       toast.error('Failed to parse annotation file');
       console.error('Parse error:', error);
     }
-    
+
     // Reset input
     e.target.value = '';
   };
@@ -132,7 +132,7 @@ export default function AnnotationEditor({
     const newAnnotations = [...localAnnotations];
     changes.forEach(([row, prop, oldValue, newValue]) => {
       if (oldValue === newValue) return;
-      
+
       const ann = newAnnotations[row];
       if (!ann) return;
 
@@ -154,16 +154,16 @@ export default function AnnotationEditor({
   }, [localAnnotations, referenceLength]);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-6xl w-full max-h-[90vh] flex flex-col">
+    <div className="fixed inset-0 flex items-center justify-center z-50 p-4" style={{ background: 'rgba(0, 0, 0, 0.6)' }}>
+      <div className="rounded-lg max-w-6xl w-full max-h-[90vh] flex flex-col" style={{ background: 'var(--gx-bg-alt)', boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.5)' }}>
         {/* Header */}
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+        <div className="p-4 flex justify-between items-center" style={{ borderBottom: '1px solid var(--gx-border)' }}>
+          <h2 className="text-xl font-bold" style={{ color: 'var(--gx-text-bright)' }}>
             Annotations for {ringName}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            style={{ color: 'var(--gx-text-muted)' }}
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -172,8 +172,8 @@ export default function AnnotationEditor({
         </div>
 
         {/* Toolbar */}
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex gap-2 flex-wrap">
-          <label className="px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 cursor-pointer">
+        <div className="p-4 flex gap-2 flex-wrap" style={{ borderBottom: '1px solid var(--gx-border)' }}>
+          <label className="btn-primary cursor-pointer text-sm">
             <input
               type="file"
               accept=".csv,.tsv,.txt"
@@ -184,24 +184,25 @@ export default function AnnotationEditor({
           </label>
           <button
             onClick={handleAddNew}
-            className="px-3 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+            className="btn-secondary text-sm"
           >
             Add New
           </button>
           <button
             onClick={handleDeleteSelected}
-            className="px-3 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+            className="btn-secondary text-sm"
+            style={{ borderColor: 'var(--gx-error)', color: 'var(--gx-error)' }}
           >
             Delete Selected
           </button>
           <button
             onClick={handleExport}
             disabled={localAnnotations.length === 0}
-            className="px-3 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 disabled:opacity-50"
+            className="btn-secondary text-sm disabled:opacity-50"
           >
             Export TSV
           </button>
-          <div className="ml-auto text-sm text-gray-600 dark:text-gray-400 self-center">
+          <div className="ml-auto text-sm self-center" style={{ color: 'var(--gx-text-muted)' }}>
             {localAnnotations.length} annotation(s) | Reference: {referenceLength.toLocaleString()} bp
           </div>
         </div>
@@ -238,16 +239,16 @@ export default function AnnotationEditor({
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-2">
+        <div className="p-4 flex justify-end gap-2" style={{ borderTop: '1px solid var(--gx-border)' }}>
           <button
             onClick={onClose}
-            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="btn-secondary"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
-            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            className="btn-primary"
           >
             Save & Close
           </button>

--- a/components/CircularPlot.tsx
+++ b/components/CircularPlot.tsx
@@ -54,7 +54,7 @@ export default function CircularPlot({ data, imageProperties }: CircularPlotProp
 
     renderer.setTooltipCallback((info) => setTooltip(info));
     renderer.render(containerRef.current, data);
-    
+
     // Get the SVG element
     const svg = containerRef.current.querySelector('svg');
     if (svg) {
@@ -71,7 +71,7 @@ export default function CircularPlot({ data, imageProperties }: CircularPlotProp
         const viewBox = svgRef.current.viewBox.baseVal;
         const cx = viewBox.width / 2;
         const cy = viewBox.height / 2;
-        
+
         // Apply transform with proper origin
         mainGroup.setAttribute(
           'transform',
@@ -117,11 +117,12 @@ export default function CircularPlot({ data, imageProperties }: CircularPlotProp
   return (
     <div className="relative">
       {/* Zoom Controls */}
-      <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-2 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-2 border border-gray-200 dark:border-gray-700">
+      <div className="absolute bottom-4 right-4 z-10 flex flex-col gap-2 rounded-lg p-2" style={{ background: 'var(--gx-bg-alt)', border: '1px solid var(--gx-border)', boxShadow: 'var(--gx-shadow)' }}>
         <button
           type="button"
           onClick={handleZoomIn}
-          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          className="p-2 rounded transition-colors"
+          style={{ color: 'var(--gx-text)' }}
           title="Zoom In"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -131,7 +132,8 @@ export default function CircularPlot({ data, imageProperties }: CircularPlotProp
         <button
           type="button"
           onClick={handleZoomOut}
-          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          className="p-2 rounded transition-colors"
+          style={{ color: 'var(--gx-text)' }}
           title="Zoom Out"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -141,20 +143,21 @@ export default function CircularPlot({ data, imageProperties }: CircularPlotProp
         <button
           type="button"
           onClick={handleResetView}
-          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          className="p-2 rounded transition-colors"
+          style={{ color: 'var(--gx-text)' }}
           title="Reset View"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
         </button>
-        <div className="text-xs text-center text-gray-600 dark:text-gray-400 py-1 border-t border-gray-200 dark:border-gray-700">
+        <div className="text-xs text-center py-1" style={{ color: 'var(--gx-text-muted)', borderTop: '1px solid var(--gx-border)' }}>
           {Math.round(zoom * 100)}%
         </div>
       </div>
 
-      <div 
-        ref={containerRef} 
+      <div
+        ref={containerRef}
         className="w-full overflow-hidden cursor-move"
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
@@ -162,26 +165,30 @@ export default function CircularPlot({ data, imageProperties }: CircularPlotProp
         onMouseLeave={handleMouseUp}
         style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
       />
-      
-      
+
+
       {tooltip && tooltip.x != null && tooltip.y != null && (
         <div
-          className="fixed bg-black bg-opacity-90 text-white text-sm rounded px-3 py-2 pointer-events-none z-50"
+          className="fixed text-sm rounded px-3 py-2 pointer-events-none z-50"
           style={{
             left: tooltip.x + 10,
-            top: tooltip.y + 10
+            top: tooltip.y + 10,
+            background: 'var(--gx-bg)',
+            color: 'var(--gx-text)',
+            border: '1px solid var(--gx-border)',
+            boxShadow: 'var(--gx-shadow)',
           }}
         >
           {tooltip.type === 'gc-content' ? (
             <>
-              <div className="font-semibold">GC Content</div>
+              <div className="font-semibold" style={{ color: 'var(--gx-accent)' }}>GC Content</div>
               <div>Position: {tooltip.position?.toLocaleString()}</div>
               <div>Window: {tooltip.windowSize?.toLocaleString()} bp</div>
               <div>GC: {tooltip.gc}%</div>
             </>
           ) : (
             <>
-              <div className="font-semibold">{tooltip.queryName}</div>
+              <div className="font-semibold" style={{ color: 'var(--gx-accent)' }}>{tooltip.queryName}</div>
               {tooltip.start != null && tooltip.end != null && (
                 <div>Position: {tooltip.start.toLocaleString()} - {tooltip.end.toLocaleString()}</div>
               )}

--- a/components/ConsoleLog.tsx
+++ b/components/ConsoleLog.tsx
@@ -27,10 +27,10 @@ export default function ConsoleLog({ logs, progress }: ConsoleLogProps) {
     <div className="card mt-6">
       {/* Progress Bar */}
       {progress && progress.step !== 'idle' && progress.step !== 'Complete!' && (
-        <div className="mb-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="mb-4 pb-4" style={{ borderBottom: '1px solid var(--gx-border)' }}>
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{progress.step}</span>
-            <span className="text-sm text-gray-500 dark:text-gray-400">{progress.percent}%</span>
+            <span className="text-sm font-medium" style={{ color: 'var(--gx-text-bright)' }}>{progress.step}</span>
+            <span className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>{progress.percent}%</span>
           </div>
           <div className="progress-bg">
             <div
@@ -39,25 +39,25 @@ export default function ConsoleLog({ logs, progress }: ConsoleLogProps) {
             />
           </div>
           {progress.message && (
-            <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">{progress.message}</div>
+            <div className="mt-2 text-xs" style={{ color: 'var(--gx-text-muted)' }}>{progress.message}</div>
           )}
         </div>
       )}
-      
+
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <button
             onClick={() => setIsOpen(!isOpen)}
-            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+            style={{ color: 'var(--gx-text-muted)' }}
           >
-            {isOpen ? '▼' : '▶'}
+            {isOpen ? '\u25BC' : '\u25B6'}
           </button>
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100">Debug Console</h3>
-          <span className="text-xs text-gray-500 dark:text-gray-400">({logs.length} messages)</span>
+          <h3 className="font-semibold" style={{ color: 'var(--gx-text-bright)' }}>Debug Console</h3>
+          <span className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>({logs.length} messages)</span>
         </div>
         <button
           onClick={copyToClipboard}
-          className="btn-secondary text-xs px-3 py-1 flex items-center gap-1"
+          className="btn-secondary text-xs px-3 py-1"
           disabled={logs.length === 0}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -66,14 +66,15 @@ export default function ConsoleLog({ logs, progress }: ConsoleLogProps) {
           Copy
         </button>
       </div>
-      
+
       {isOpen && (
         <div
           ref={logRef}
-          className="bg-gray-900 dark:bg-black text-green-400 font-mono text-xs p-4 rounded max-h-96 overflow-y-auto"
+          className="font-mono text-xs p-4 rounded max-h-96 overflow-y-auto"
+          style={{ background: 'var(--gx-code-bg)', color: 'var(--gx-accent)', border: '1px solid var(--gx-border)' }}
         >
           {logs.length === 0 ? (
-            <div className="text-gray-500">No logs yet...</div>
+            <div style={{ color: 'var(--gx-text-muted)' }}>No logs yet...</div>
           ) : (
             logs.map((log, index) => (
               <div key={index} className="mb-1 whitespace-pre-wrap break-all">

--- a/components/ExportPanel.tsx
+++ b/components/ExportPanel.tsx
@@ -85,7 +85,7 @@ export default function ExportPanel({ plotData, imageProperties }: ExportPanelPr
       canvas.width = 1200;
       canvas.height = 1200;
       const ctx = canvas.getContext('2d');
-      
+
       if (!ctx) {
         throw new Error('Could not get canvas context');
       }
@@ -151,7 +151,7 @@ export default function ExportPanel({ plotData, imageProperties }: ExportPanelPr
     <div className="flex gap-2">
       <button
         onClick={exportSVG}
-        className="px-4 py-2 bg-green-600 hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600 text-white text-sm font-medium rounded-lg shadow-sm hover:shadow-md transition-all flex items-center gap-2"
+        className="btn-secondary text-xs px-3 py-1.5"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
@@ -161,7 +161,7 @@ export default function ExportPanel({ plotData, imageProperties }: ExportPanelPr
       <button
         onClick={exportPNG}
         disabled={isExporting}
-        className="px-4 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white text-sm font-medium rounded-lg shadow-sm hover:shadow-md transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="btn-secondary text-xs px-3 py-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isExporting ? (
           <>
@@ -182,7 +182,7 @@ export default function ExportPanel({ plotData, imageProperties }: ExportPanelPr
       </button>
       <button
         onClick={exportJSON}
-        className="px-4 py-2 bg-purple-600 hover:bg-purple-700 dark:bg-purple-500 dark:hover:bg-purple-600 text-white text-sm font-medium rounded-lg shadow-sm hover:shadow-md transition-all flex items-center gap-2"
+        className="btn-secondary text-xs px-3 py-1.5"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -41,17 +41,14 @@ export default function FileUpload({
           type="file"
           accept=".fasta,.fa,.fna,.gbk,.gb,.genbank,.fasta.gz,.fa.gz,.fna.gz,.gbk.gz,.gb.gz,.genbank.gz,.gz"
           onChange={handleReferenceChange}
-          className="block w-full text-sm text-gray-500 dark:text-gray-400
+          className="block w-full text-sm cursor-pointer input-field
             file:mr-4 file:py-2 file:px-4
-            file:rounded-lg file:border-0
+            file:rounded file:border-0
             file:text-sm file:font-semibold
-            file:bg-blue-50 file:text-blue-700
-            dark:file:bg-blue-900/30 dark:file:text-blue-400
-            hover:file:bg-blue-100 dark:hover:file:bg-blue-900/50
-            cursor-pointer transition-all"
+            file:cursor-pointer"
         />
         {referenceFile && (
-          <div className="mt-2 text-sm text-green-600 dark:text-green-400 flex items-center">
+          <div className="mt-2 text-sm flex items-center" style={{ color: 'var(--gx-accent)' }}>
             <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
             </svg>
@@ -69,23 +66,21 @@ export default function FileUpload({
           accept=".fasta,.fa,.fna,.gbk,.gb,.genbank,.fasta.gz,.fa.gz,.fna.gz,.gbk.gz,.gb.gz,.genbank.gz,.gz"
           multiple
           onChange={handleQueryChange}
-          className="block w-full text-sm text-gray-500 dark:text-gray-400
+          className="block w-full text-sm cursor-pointer input-field
             file:mr-4 file:py-2 file:px-4
-            file:rounded-lg file:border-0
+            file:rounded file:border-0
             file:text-sm file:font-semibold
-            file:bg-green-50 file:text-green-700
-            dark:file:bg-green-900/30 dark:file:text-green-400
-            hover:file:bg-green-100 dark:hover:file:bg-green-900/50
-            cursor-pointer transition-all"
+            file:cursor-pointer"
         />
         {queryFiles.length > 0 && (
           <div className="mt-2 space-y-1">
             {queryFiles.map((file, index) => (
-              <div key={index} className="flex items-center justify-between text-sm bg-gray-50 dark:bg-gray-700/50 p-2 rounded-lg border border-gray-200 dark:border-gray-600">
-                <span className="text-gray-700 dark:text-gray-300 truncate">{file.name}</span>
+              <div key={index} className="flex items-center justify-between text-sm p-2 rounded-lg" style={{ background: 'var(--gx-bg-elevated)', border: '1px solid var(--gx-border)' }}>
+                <span className="truncate" style={{ color: 'var(--gx-text)' }}>{file.name}</span>
                 <button
                   onClick={() => removeQueryFile(index)}
-                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 ml-2 p-1 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                  className="ml-2 p-1 rounded transition-colors"
+                  style={{ color: 'var(--gx-error)' }}
                   aria-label="Remove file"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/ImageProperties.tsx
+++ b/components/ImageProperties.tsx
@@ -39,30 +39,30 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
           value={config.title}
           onChange={(e) => handleChange('title', e.target.value)}
           placeholder="Enter plot title..."
-          className="input"
+          className="input-field w-full"
         />
       </div>
 
-      <div className="flex items-center justify-between mb-3 border-t border-gray-200 dark:border-gray-700 pt-4">
+      <div className="flex items-center justify-between mb-3 pt-4" style={{ borderTop: '1px solid var(--gx-border)' }}>
         <div className="flex items-center gap-2">
           <button
             onClick={() => setIsOpen(!isOpen)}
-            className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+            style={{ color: 'var(--gx-text-muted)' }}
           >
-            {isOpen ? '▼' : '▶'}
+            {isOpen ? '\u25BC' : '\u25B6'}
           </button>
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100">Image Properties</h3>
+          <h3 className="font-semibold" style={{ color: 'var(--gx-text-bright)' }}>Image Properties</h3>
         </div>
       </div>
-      
+
       {isOpen && (
         <div className="space-y-4">
           {/* Ring Dimensions */}
           <div className="space-y-3">
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700 pb-1">
+            <h4 className="text-sm font-semibold pb-1" style={{ color: 'var(--gx-text-bright)', borderBottom: '1px solid var(--gx-border)' }}>
               Ring Dimensions
             </h4>
-            
+
             <div>
               <label className="label">
                 Inner Radius: {config.innerRadius}px
@@ -74,7 +74,8 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="10"
                 value={config.innerRadius}
                 onChange={(e) => handleChange('innerRadius', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
             </div>
 
@@ -89,9 +90,10 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="5"
                 value={config.ringWidth}
                 onChange={(e) => handleChange('ringWidth', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
-              <span className="text-xs text-gray-500 dark:text-gray-400">Alignment rings</span>
+              <span className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>Alignment rings</span>
             </div>
 
             <div>
@@ -105,9 +107,10 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="5"
                 value={config.gcRingWidth}
                 onChange={(e) => handleChange('gcRingWidth', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
-              <span className="text-xs text-gray-500 dark:text-gray-400">GC Content & Skew rings</span>
+              <span className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>GC Content & Skew rings</span>
             </div>
 
             <div>
@@ -121,17 +124,18 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="1"
                 value={config.ringSpacing}
                 onChange={(e) => handleChange('ringSpacing', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
             </div>
           </div>
 
           {/* Font Sizes */}
           <div className="space-y-3">
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700 pb-1">
+            <h4 className="text-sm font-semibold pb-1" style={{ color: 'var(--gx-text-bright)', borderBottom: '1px solid var(--gx-border)' }}>
               Font Sizes
             </h4>
-            
+
             <div>
               <label className="label">
                 Legend Font: {config.legendFontSize}px
@@ -143,7 +147,8 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="1"
                 value={config.legendFontSize}
                 onChange={(e) => handleChange('legendFontSize', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
             </div>
 
@@ -158,7 +163,8 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="1"
                 value={config.scaleFontSize}
                 onChange={(e) => handleChange('scaleFontSize', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
             </div>
 
@@ -173,7 +179,8 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="2"
                 value={config.titleFontSize}
                 onChange={(e) => handleChange('titleFontSize', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
             </div>
             <div>
@@ -187,9 +194,11 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
                 step="1"
                 value={config.labelFontSize}
                 onChange={(e) => handleChange('labelFontSize', parseInt(e.target.value))}
-                className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+                style={{ accentColor: 'var(--gx-accent)', background: 'var(--gx-bg)' }}
               />
-            </div>          </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/components/ParameterControls.tsx
+++ b/components/ParameterControls.tsx
@@ -33,7 +33,7 @@ export default function ParameterControls({
           step="100"
           className="input-field w-full disabled:opacity-50 disabled:cursor-not-allowed"
         />
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-xs" style={{ color: 'var(--gx-text-muted)' }}>
           Resolution of the circular plot (100-10000)
         </p>
       </div>
@@ -54,7 +54,7 @@ export default function ParameterControls({
           max="100"
           className="input-field w-full disabled:opacity-50 disabled:cursor-not-allowed"
         />
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-xs" style={{ color: 'var(--gx-text-muted)' }}>
           Filter alignments below this identity (50-100)
         </p>
       </div>
@@ -76,7 +76,7 @@ export default function ParameterControls({
           step="50"
           className="input-field w-full disabled:opacity-50 disabled:cursor-not-allowed"
         />
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-xs" style={{ color: 'var(--gx-text-muted)' }}>
           Filter short alignments (50-5000)
         </p>
       </div>
@@ -88,11 +88,12 @@ export default function ParameterControls({
             checked={params.forceAlignment}
             onChange={(e) => setParams({ ...params, forceAlignment: e.target.checked })}
             disabled={disabled}
-            className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-4 h-4 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ accentColor: 'var(--gx-accent)' }}
           />
           <span className="label mb-0">Force Re-alignment</span>
         </label>
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-xs" style={{ color: 'var(--gx-text-muted)' }}>
           Re-run alignment even if cached results exist
         </p>
       </div>
@@ -109,7 +110,7 @@ export default function ParameterControls({
           placeholder="e.g., --step=20 --seed=match12"
           className="input-field w-full disabled:opacity-50 disabled:cursor-not-allowed font-mono text-sm"
         />
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-xs" style={{ color: 'var(--gx-text-muted)' }}>
           Custom LASTZ parameters (default: --ambiguous=iupac --gapped --chain)
         </p>
       </div>

--- a/components/ProgressPanel.tsx
+++ b/components/ProgressPanel.tsx
@@ -10,8 +10,8 @@ export default function ProgressPanel({ progress }: ProgressPanelProps) {
   return (
     <div className="card animate-fade-in">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{progress.step}</span>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{progress.percent}%</span>
+        <span className="text-sm font-medium" style={{ color: 'var(--gx-text-bright)' }}>{progress.step}</span>
+        <span className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>{progress.percent}%</span>
       </div>
       <div className="progress-bg">
         <div
@@ -20,7 +20,7 @@ export default function ProgressPanel({ progress }: ProgressPanelProps) {
         />
       </div>
       {progress.message && (
-        <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">{progress.message}</div>
+        <div className="mt-2 text-xs" style={{ color: 'var(--gx-text-muted)' }}>{progress.message}</div>
       )}
     </div>
   );

--- a/components/RingConfiguration.tsx
+++ b/components/RingConfiguration.tsx
@@ -59,7 +59,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
     if (!files) return;
     const ring = rings.find(r => r.id === id);
     if (!ring) return;
-    
+
     const newFiles = Array.from(files);
     updateRing(id, { files: [...ring.files, ...newFiles] });
   };
@@ -67,7 +67,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
   const removeFileFromRing = (ringId: string, fileIndex: number) => {
     const ring = rings.find(r => r.id === ringId);
     if (!ring) return;
-    
+
     updateRing(ringId, { files: ring.files.filter((_, i) => i !== fileIndex) });
   };
 
@@ -75,7 +75,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
     const newRings = [...rings];
     const targetIndex = direction === 'up' ? index - 1 : index + 1;
     if (targetIndex < 0 || targetIndex >= rings.length) return;
-    
+
     [newRings[index], newRings[targetIndex]] = [newRings[targetIndex], newRings[index]];
     setRings(newRings);
   };
@@ -83,20 +83,20 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
   return (
     <div className="space-y-4">
       <div className="flex justify-between items-center">
-        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Ring Configuration</h3>
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--gx-text-bright)' }}>Ring Configuration</h3>
         <button
           type="button"
           onClick={addNewRing}
-          className="text-sm btn-secondary px-3 py-1"
+          className="btn-secondary text-xs px-3 py-1"
         >
           + Add New Ring
         </button>
       </div>
 
       {rings.length === 0 && (
-        <div className="text-center py-8 text-gray-500 dark:text-gray-400 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
+        <div className="text-center py-8 rounded-lg" style={{ color: 'var(--gx-text-muted)', border: '2px dashed var(--gx-border)' }}>
           <p className="mb-2">No rings configured</p>
-          <p className="text-sm">Click "Add New Ring" to start</p>
+          <p className="text-sm">Click &quot;Add New Ring&quot; to start</p>
         </div>
       )}
 
@@ -104,7 +104,8 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
         {rings.map((ring, index) => (
           <div
             key={ring.id}
-            className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 bg-gray-50 dark:bg-gray-700/50"
+            className="rounded-lg p-4"
+            style={{ border: '1px solid var(--gx-border)', background: 'var(--gx-bg-elevated)' }}
           >
             <div className="flex items-start justify-between mb-3">
               <div className="flex items-center gap-2 flex-1">
@@ -113,17 +114,19 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
                     type="button"
                     onClick={() => moveRing(index, 'up')}
                     disabled={index === 0}
-                    className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed"
+                    className="disabled:opacity-30 disabled:cursor-not-allowed"
+                    style={{ color: 'var(--gx-text-muted)' }}
                   >
-                    ▲
+                    &#9650;
                   </button>
                   <button
                     type="button"
                     onClick={() => moveRing(index, 'down')}
                     disabled={index === rings.length - 1}
-                    className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 disabled:cursor-not-allowed"
+                    className="disabled:opacity-30 disabled:cursor-not-allowed"
+                    style={{ color: 'var(--gx-text-muted)' }}
                   >
-                    ▼
+                    &#9660;
                   </button>
                 </div>
                 <input
@@ -137,12 +140,12 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
                   <button
                     type="button"
                     onClick={() => setColorPickerOpen(colorPickerOpen === ring.id ? null : ring.id)}
-                    className="w-10 h-8 rounded border-2 border-gray-300 dark:border-gray-500 cursor-pointer"
-                    style={{ backgroundColor: ring.color }}
+                    className="w-10 h-8 rounded cursor-pointer"
+                    style={{ backgroundColor: ring.color, border: '2px solid var(--gx-border)' }}
                     title="Ring color"
                   />
                   {colorPickerOpen === ring.id && (
-                    <div className="absolute top-10 right-0 z-10 p-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg">
+                    <div className="absolute top-10 right-0 z-10 p-2 rounded-lg" style={{ background: 'var(--gx-bg-alt)', border: '1px solid var(--gx-border)', boxShadow: 'var(--gx-shadow)' }}>
                       <input
                         type="color"
                         value={ring.color}
@@ -156,16 +159,17 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
               <button
                 type="button"
                 onClick={() => removeRing(ring.id)}
-                className="text-red-500 hover:text-red-700 dark:hover:text-red-400 ml-2"
+                className="ml-2"
+                style={{ color: 'var(--gx-error)' }}
                 title="Remove ring"
               >
-                ✕
+                &#10005;
               </button>
             </div>
 
             <div className="grid grid-cols-2 gap-3 mb-3">
               <div>
-                <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Upper Threshold (%)</label>
+                <label className="block text-xs mb-1" style={{ color: 'var(--gx-text-muted)' }}>Upper Threshold (%)</label>
                 <input
                   type="number"
                   min="50"
@@ -176,7 +180,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Lower Threshold (%)</label>
+                <label className="block text-xs mb-1" style={{ color: 'var(--gx-text-muted)' }}>Lower Threshold (%)</label>
                 <input
                   type="number"
                   min="50"
@@ -189,9 +193,9 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
             </div>
 
             <div className="mb-3">
-              <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
-                Custom Ring Width (px) 
-                <span className="text-gray-500 ml-1">(leave empty for default)</span>
+              <label className="block text-xs mb-1" style={{ color: 'var(--gx-text-muted)' }}>
+                Custom Ring Width (px)
+                <span className="ml-1" style={{ color: 'var(--gx-text-muted)', opacity: 0.7 }}>(leave empty for default)</span>
               </label>
               <input
                 type="number"
@@ -206,7 +210,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
 
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
+                <label className="block text-xs font-medium" style={{ color: 'var(--gx-text-muted)' }}>
                   Files ({ring.files.length})
                 </label>
                 <div className="flex gap-2">
@@ -214,12 +218,13 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
                     <button
                       type="button"
                       onClick={() => onEditAnnotations(ring.id)}
-                      className="text-xs text-purple-600 dark:text-purple-400 hover:underline"
+                      className="text-xs hover:underline"
+                      style={{ color: 'var(--gx-indigo)' }}
                     >
-                      📝 Annotations
+                      Annotations
                     </button>
                   )}
-                  <label className="text-xs text-blue-600 dark:text-blue-400 hover:underline cursor-pointer">
+                  <label className="text-xs cursor-pointer hover:underline" style={{ color: 'var(--gx-accent)' }}>
                     + Add Files
                     <input
                       type="file"
@@ -231,21 +236,23 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
                   </label>
                 </div>
               </div>
-              
+
               {ring.files.length > 0 && (
                 <div className="space-y-1">
                   {ring.files.map((file, fileIndex) => (
                     <div
                       key={fileIndex}
-                      className="flex items-center justify-between text-xs bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600"
+                      className="flex items-center justify-between text-xs px-2 py-1 rounded"
+                      style={{ background: 'var(--gx-bg-alt)', border: '1px solid var(--gx-border)' }}
                     >
-                      <span className="truncate flex-1" title={file.name}>{file.name}</span>
+                      <span className="truncate flex-1" title={file.name} style={{ color: 'var(--gx-text)' }}>{file.name}</span>
                       <button
                         type="button"
                         onClick={() => removeFileFromRing(ring.id, fileIndex)}
-                        className="text-red-500 hover:text-red-700 ml-2"
+                        className="ml-2"
+                        style={{ color: 'var(--gx-error)' }}
                       >
-                        ✕
+                        &#10005;
                       </button>
                     </div>
                   ))}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -2,47 +2,52 @@
 
 import { useEffect, useState } from 'react';
 
+type Theme = 'dark' | 'light';
+
 export default function ThemeToggle() {
-  const [darkMode, setDarkMode] = useState(false);
+  const [theme, setTheme] = useState<Theme>('dark');
 
   useEffect(() => {
-    // Check for saved theme preference or default to system preference
-    const savedTheme = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    
-    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
-      setDarkMode(true);
-      document.documentElement.classList.add('dark');
-    }
+    const saved = localStorage.getItem('gx-theme') as Theme | null;
+    const current = saved || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    setTheme(current);
+    document.documentElement.setAttribute('data-theme', current);
   }, []);
 
-  const toggleTheme = () => {
-    if (darkMode) {
-      document.documentElement.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
-      setDarkMode(false);
-    } else {
-      document.documentElement.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-      setDarkMode(true);
-    }
+  const applyTheme = (t: Theme) => {
+    setTheme(t);
+    document.documentElement.setAttribute('data-theme', t);
+    localStorage.setItem('gx-theme', t);
   };
 
   return (
-    <button
-      onClick={toggleTheme}
-      className="fixed top-4 right-4 z-50 p-3 rounded-full bg-white dark:bg-gray-800 shadow-lg hover:shadow-xl transition-all duration-200 border border-gray-200 dark:border-gray-700"
-      aria-label="Toggle theme"
-    >
-      {darkMode ? (
-        <svg className="w-5 h-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
-          <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
-        </svg>
-      ) : (
-        <svg className="w-5 h-5 text-gray-700" fill="currentColor" viewBox="0 0 20 20">
+    <div className="flex items-center rounded-full border border-gx-border overflow-hidden text-xs font-medium">
+      <button
+        onClick={() => applyTheme('dark')}
+        className={`px-3 py-1.5 transition-colors ${
+          theme === 'dark'
+            ? 'bg-gx-accent text-[#0F172A]'
+            : 'text-gx-text-muted hover:text-gx-text'
+        }`}
+        aria-label="Dark theme"
+      >
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
           <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
         </svg>
-      )}
-    </button>
+      </button>
+      <button
+        onClick={() => applyTheme('light')}
+        className={`px-3 py-1.5 transition-colors ${
+          theme === 'light'
+            ? 'bg-gx-accent text-[#0F172A]'
+            : 'text-gx-text-muted hover:text-gx-text'
+        }`}
+        aria-label="Light theme"
+      >
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+          <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+        </svg>
+      </button>
+    </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@types/jest": "^29.5.14",
+        "@types/jest": "^29.5.12",
         "@types/node": "^22",
         "@types/pako": "^2.0.4",
         "@types/react": "^19",
@@ -32,15 +31,9 @@
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.1.2",
         "typescript": "^5"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1591,25 +1584,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1904,15 +1878,6 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/asynckit": {
@@ -2435,9 +2400,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -2523,12 +2488,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2677,12 +2636,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true
     },
     "node_modules/domexception": {
@@ -3337,9 +3290,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.1.1.tgz",
-      "integrity": "sha512-v+yvRPZGL73KinH2lvS4/1QMe2xNviTfgIcVgKjzKGi66xEuvuoDRgQ48ODc4XhD+c+JLNfs9Ln1GnHQ5TDNGA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.2.0.tgz",
+      "integrity": "sha512-2vzQKKVMDPLsubZJb0JJWT/DhrkgIjsWj40Z9BIUVT6Jkl/YM5VtkLOP3agCieqW9HuqnXlWc+Vi+7XzQuC1Nw==",
       "optional": true,
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -3389,15 +3342,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4433,15 +4377,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5173,19 +5108,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/regexp-to-ast": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
@@ -5511,18 +5433,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "@biowasm/aioli": "^3.2.1",
+    "@handsontable/react": "^16.2.0",
     "comlink": "^4.4.1",
+    "handsontable": "^16.2.0",
     "idb": "^8.0.0",
     "next": "^15.5.9",
     "pako": "^2.1.0",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
-  darkMode: 'class',
+  darkMode: ['selector', '[data-theme="dark"]'],
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -10,14 +10,25 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        primary: {
-          light: '#3b82f6',
-          dark: '#60a5fa',
+        gx: {
+          bg: 'var(--gx-bg)',
+          'bg-alt': 'var(--gx-bg-alt)',
+          'bg-elevated': 'var(--gx-bg-elevated)',
+          text: 'var(--gx-text)',
+          'text-muted': 'var(--gx-text-muted)',
+          'text-bright': 'var(--gx-text-bright)',
+          border: 'var(--gx-border)',
+          accent: 'var(--gx-accent)',
+          'accent-hover': 'var(--gx-accent-hover)',
+          indigo: 'var(--gx-indigo)',
+          success: 'var(--gx-success)',
+          warning: 'var(--gx-warning)',
+          error: 'var(--gx-error)',
         },
-        background: {
-          light: '#f9fafb',
-          dark: '#111827',
-        },
+      },
+      fontFamily: {
+        sans: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
       },
       animation: {
         'fade-in': 'fadeIn 0.5s ease-in',


### PR DESCRIPTION
## Summary

- Replaces the blue color scheme with GenomicX teal (`#14B8A6`) accent and dark navy (`#0F172A`) backgrounds
- Introduces a full CSS custom property design token system (`--gx-*`) matching the [GenomicX front-end template](https://github.com/genomicx/genomicx.github.io/tree/main/front-end-template)
- Switches from class-based dark mode to `data-theme` attribute theming (dark-first, with light mode support)
- Replaces the blue gradient header with a frosted glass navigation bar (`backdrop-filter: blur`)
- Adds Inter (UI font) and JetBrains Mono (code font) from Google Fonts
- Restyles all 10 components: cards, buttons, form controls, tooltips, progress bars, console log, export panel, annotation editor, ring configuration, and theme toggle
- Theme toggle redesigned as a compact pill-style dark/light switcher integrated into the nav bar

## Changes

| Area | Before | After |
|---|---|---|
| Accent color | Blue (`#3b82f6`) | Teal (`#14B8A6`) |
| Dark mode | `.dark` class on `<html>` | `data-theme="dark"` attribute |
| Navigation | Blue gradient, opaque | Frosted glass, `backdrop-blur(12px)` |
| Cards | White/gray with shadow | `--gx-bg-alt` with teal hover border |
| Buttons | Blue primary, gray secondary | Teal primary, transparent border secondary |
| Fonts | System stack | Inter + JetBrains Mono |
| Theme toggle | Floating circle button | Inline pill in nav bar |

## Files changed (15)

- `tailwind.config.ts` - GenomicX color tokens, Inter/JetBrains Mono fonts, `data-theme` dark mode selector
- `app/globals.css` - Full `--gx-*` design token system, restyled component classes
- `app/layout.tsx` - Theme initialization script, removed floating ThemeToggle
- `app/page.tsx` - Frosted glass nav, restyled cards/stats/footer
- `app/about/page.tsx` - Matching nav/footer/content styling
- `components/ThemeToggle.tsx` - Pill-style dark/light toggle
- `components/*.tsx` (9 files) - Updated to use GenomicX design tokens

## Test plan

- [ ] Verify dark theme renders correctly (default)
- [ ] Verify light theme renders correctly via toggle
- [ ] Verify theme persists across page reload (localStorage `gx-theme`)
- [ ] Check frosted glass nav blur effect on scroll
- [ ] Upload a reference genome and verify plot renders
- [ ] Run alignments and verify progress bar / console log styling
- [ ] Test export buttons (SVG, PNG, Data)
- [ ] Test annotation editor modal styling
- [ ] Verify responsive layout on mobile viewport
- [ ] Verify About page styling matches main page

🤖 Generated with [Claude Code](https://claude.com/claude-code)