### PR TITLE
feat: align design tokens with ronaQC standard

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -17,7 +17,7 @@ export default function AboutPage() {
                 <circle cx="12" cy="12" r="2" />
               </svg>
               <div>
-                <h1 className="text-lg font-bold" style={{ color: 'var(--gx-text-bright)' }}>BRIGX</h1>
+                <h1 className="text-lg font-bold" style={{ color: 'var(--gx-text)' }}>BRIGX</h1>
                 <p className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>BLAST Ring Image Generator</p>
               </div>
             </Link>
@@ -35,17 +35,17 @@ export default function AboutPage() {
       <main className="flex-grow py-12">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="card">
-            <h1 className="text-4xl font-bold mb-8" style={{ color: 'var(--gx-text-bright)', letterSpacing: '-0.025em' }}>About BRIGX</h1>
+            <h1 className="text-4xl font-bold mb-8" style={{ color: 'var(--gx-text)', letterSpacing: '-0.025em' }}>About BRIGX</h1>
 
             <div className="max-w-none">
-              <h2 className="text-2xl font-semibold mt-6 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Overview</h2>
+              <h2 className="text-2xl font-semibold mt-6 mb-4" style={{ color: 'var(--gx-text)' }}>Overview</h2>
               <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 BRIGX (BLAST Ring Image Generator eXtended) is a web-based tool for comparative genomics visualization.
                 It creates circular genome comparison plots similar to the original BRIG tool, but runs entirely in your browser
                 using WebAssembly technology.
               </p>
 
-              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Features</h2>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text)' }}>Features</h2>
               <ul className="list-disc pl-6 space-y-2 mb-4" style={{ color: 'var(--gx-text)' }}>
                 <li>Compare multiple genome sequences against a reference genome</li>
                 <li>Interactive circular visualization with multiple rings</li>
@@ -56,28 +56,28 @@ export default function AboutPage() {
                 <li>All processing happens locally in your browser</li>
               </ul>
 
-              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>How It Works</h2>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text)' }}>How It Works</h2>
               <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 BRIGX uses LASTZ, a powerful DNA sequence alignment tool, compiled to WebAssembly. This allows
                 sophisticated bioinformatics analysis to run directly in your web browser without requiring any
                 server-side processing or data upload.
               </p>
 
-              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Privacy</h2>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text)' }}>Privacy</h2>
               <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 All processing happens locally in your browser using WebAssembly. Your genome data never leaves
                 your computer, ensuring complete privacy and security of your research data.
               </p>
 
-              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Technology Stack</h2>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text)' }}>Technology Stack</h2>
               <ul className="list-disc pl-6 space-y-2 mb-4" style={{ color: 'var(--gx-text)' }}>
-                <li><strong style={{ color: 'var(--gx-text-bright)' }}>LASTZ:</strong> DNA sequence alignment tool (v1.04.52)</li>
-                <li><strong style={{ color: 'var(--gx-text-bright)' }}>WebAssembly:</strong> High-performance browser execution</li>
-                <li><strong style={{ color: 'var(--gx-text-bright)' }}>Next.js:</strong> React framework for the user interface</li>
-                <li><strong style={{ color: 'var(--gx-text-bright)' }}>Web Workers:</strong> Parallel processing for faster alignments</li>
+                <li><strong style={{ color: 'var(--gx-text)' }}>LASTZ:</strong> DNA sequence alignment tool (v1.04.52)</li>
+                <li><strong style={{ color: 'var(--gx-text)' }}>WebAssembly:</strong> High-performance browser execution</li>
+                <li><strong style={{ color: 'var(--gx-text)' }}>Next.js:</strong> React framework for the user interface</li>
+                <li><strong style={{ color: 'var(--gx-text)' }}>Web Workers:</strong> Parallel processing for faster alignments</li>
               </ul>
 
-              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Citation</h2>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text)' }}>Citation</h2>
               <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 If you use BRIGX in your research, please cite the original BRIG paper:
               </p>
@@ -86,7 +86,7 @@ export default function AboutPage() {
                 simple prokaryote genome comparisons. BMC Genomics 12:402.
               </blockquote>
 
-              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text-bright)' }}>Contributing</h2>
+              <h2 className="text-2xl font-semibold mt-8 mb-4" style={{ color: 'var(--gx-text)' }}>Contributing</h2>
               <p className="mb-4" style={{ color: 'var(--gx-text)' }}>
                 BRIGX is an open-source project. You can edit this page and contribute to the project on GitHub.
               </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,44 +4,50 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ── GenomicX Design Tokens ── */
+/* ── GenomicX Design Tokens (ronaQC standard) ── */
 :root {
-  /* Dark theme (default) */
-  --gx-bg: #0F172A;
-  --gx-bg-alt: #1E293B;
-  --gx-bg-elevated: #253349;
-  --gx-text: #E2E8F0;
-  --gx-text-muted: #94A3B8;
-  --gx-text-bright: #F1F5F9;
-  --gx-border: #334155;
-  --gx-accent: #14B8A6;
-  --gx-accent-hover: #2DD4BF;
-  --gx-accent-dim: rgba(20, 184, 166, 0.1);
-  --gx-accent-15: rgba(20, 184, 166, 0.15);
+  /* Light theme (default) */
+  --gx-bg: #f8fafc;
+  --gx-bg-alt: #f1f5f9;
+  --gx-surface: #ffffff;
+  --gx-surface-hover: #f1f5f9;
+  --gx-bg-elevated: #ffffff; /* alias for --gx-surface */
+  --gx-text: #0f172a;
+  --gx-text-muted: #64748b;
+  --gx-text-bright: #0f172a;
+  --gx-text-inverted: #ffffff;
+  --gx-border: #e2e8f0;
+  --gx-accent: #0d9488;
+  --gx-accent-hover: #0f766e;
   --gx-indigo: #6366F1;
-  --gx-indigo-dim: rgba(99, 102, 241, 0.1);
-  --gx-success: #14B8A6;
+  --gx-success: #0d9488;
   --gx-warning: #F59E0B;
   --gx-error: #EF4444;
-  --gx-nav-bg: rgba(15, 23, 42, 0.9);
-  --gx-code-bg: #0F172A;
-  --gx-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --gx-nav-bg: rgba(255, 255, 255, 0.9);
+  --gx-code-bg: #f1f5f9;
+  --gx-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   --gx-transition: 0.2s ease;
   --gx-radius: 8px;
   --gx-radius-lg: 12px;
 }
 
-[data-theme="light"] {
-  --gx-bg: #FFFFFF;
-  --gx-bg-alt: #F8FAFC;
-  --gx-bg-elevated: #F1F5F9;
-  --gx-text: #334155;
-  --gx-text-muted: #64748B;
-  --gx-text-bright: #0F172A;
-  --gx-border: #E2E8F0;
-  --gx-nav-bg: rgba(255, 255, 255, 0.9);
-  --gx-code-bg: #F1F5F9;
-  --gx-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+[data-theme="dark"] {
+  --gx-bg: #0f172a;
+  --gx-bg-alt: #1e293b;
+  --gx-surface: #1e293b;
+  --gx-surface-hover: #334155;
+  --gx-bg-elevated: #1e293b; /* alias for --gx-surface */
+  --gx-text: #f1f5f9;
+  --gx-text-muted: #94a3b8;
+  --gx-text-bright: #f1f5f9;
+  --gx-text-inverted: #0f172a;
+  --gx-border: #334155;
+  --gx-accent: #2dd4bf;
+  --gx-accent-hover: #14b8a6;
+  --gx-indigo: #818cf8;
+  --gx-nav-bg: rgba(15, 23, 42, 0.9);
+  --gx-code-bg: #0f172a;
+  --gx-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 @layer base {
@@ -88,7 +94,7 @@
     justify-content: center;
     gap: 0.5rem;
     background: var(--gx-accent);
-    color: #0F172A;
+    color: var(--gx-text-inverted);
     font-weight: 600;
     font-size: 0.875rem;
     padding: 0.7rem 1.4rem;
@@ -147,14 +153,14 @@
     display: block;
     font-size: 0.8125rem;
     font-weight: 500;
-    color: var(--gx-text-bright);
+    color: var(--gx-text);
     margin-bottom: 0.5rem;
   }
 
   .section-title {
     font-size: 1.25rem;
     font-weight: 700;
-    color: var(--gx-text-bright);
+    color: var(--gx-text);
     margin-bottom: 1rem;
     letter-spacing: -0.01em;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -461,7 +461,7 @@ export default function Home() {
                   <circle cx="12" cy="12" r="1" fill="var(--gx-accent)" />
                 </svg>
                 <div>
-                  <h1 className="text-lg font-bold" style={{ color: 'var(--gx-text-bright)' }}>BRIGX</h1>
+                  <h1 className="text-lg font-bold" style={{ color: 'var(--gx-text)' }}>BRIGX</h1>
                   <p className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>Browser-based Ring Image Generator</p>
                 </div>
               </div>
@@ -591,33 +591,33 @@ export default function Home() {
                   <div className="mt-6 card animate-fade-in">
                     <h2 className="section-title">Statistics</h2>
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-accent-dim)', border: '1px solid var(--gx-border)' }}>
+                      <div className="p-4 rounded-lg" style={{ background: 'color-mix(in srgb, var(--gx-accent) 10%, transparent)', border: '1px solid var(--gx-border)' }}>
                         <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Reference</div>
-                        <div className="text-base font-semibold truncate mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.reference.name}</div>
+                        <div className="text-base font-semibold truncate mt-1" style={{ color: 'var(--gx-text)' }}>{plotData.reference.name}</div>
                         <div className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>{(plotData.reference.length / 1000).toFixed(1)} kb</div>
                       </div>
-                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-accent-dim)', border: '1px solid var(--gx-border)' }}>
+                      <div className="p-4 rounded-lg" style={{ background: 'color-mix(in srgb, var(--gx-accent) 10%, transparent)', border: '1px solid var(--gx-border)' }}>
                         <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Query Genomes</div>
-                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.rings?.length || 0}</div>
+                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text)' }}>{plotData.rings?.length || 0}</div>
                       </div>
-                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-indigo-dim)', border: '1px solid var(--gx-border)' }}>
+                      <div className="p-4 rounded-lg" style={{ background: 'color-mix(in srgb, var(--gx-indigo) 10%, transparent)', border: '1px solid var(--gx-border)' }}>
                         <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Window Size</div>
-                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.config?.windowSize || 0} bp</div>
+                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text)' }}>{plotData.config?.windowSize || 0} bp</div>
                       </div>
-                      <div className="p-4 rounded-lg" style={{ background: 'var(--gx-indigo-dim)', border: '1px solid var(--gx-border)' }}>
+                      <div className="p-4 rounded-lg" style={{ background: 'color-mix(in srgb, var(--gx-indigo) 10%, transparent)', border: '1px solid var(--gx-border)' }}>
                         <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--gx-text-muted)' }}>Min Identity</div>
-                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text-bright)' }}>{plotData.config?.minIdentity || 0}%</div>
+                        <div className="text-2xl font-bold mt-1" style={{ color: 'var(--gx-text)' }}>{plotData.config?.minIdentity || 0}%</div>
                       </div>
                     </div>
 
                     {plotData.rings && plotData.rings.length > 0 && (
                       <div className="mt-6">
-                        <h3 className="font-semibold mb-3" style={{ color: 'var(--gx-text-bright)' }}>Query Genome Coverage</h3>
+                        <h3 className="font-semibold mb-3" style={{ color: 'var(--gx-text)' }}>Query Genome Coverage</h3>
                         <div className="space-y-2">
                           {plotData.rings.map((ring) => (
-                            <div key={ring.queryId} className="flex items-center justify-between p-3 rounded-lg transition-colors" style={{ background: 'var(--gx-bg-elevated)', border: '1px solid var(--gx-border)' }}>
+                            <div key={ring.queryId} className="flex items-center justify-between p-3 rounded-lg transition-colors" style={{ background: 'var(--gx-surface)', border: '1px solid var(--gx-border)' }}>
                               <div className="flex-1">
-                                <div className="font-medium" style={{ color: 'var(--gx-text-bright)' }}>{ring.queryName}</div>
+                                <div className="font-medium" style={{ color: 'var(--gx-text)' }}>{ring.queryName}</div>
                                 <div className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>
                                   Coverage: {ring.statistics.genomeCoverage.toFixed(1)}% |
                                   Avg Identity: {ring.statistics.meanIdentity.toFixed(1)}%

--- a/components/AnnotationEditor.tsx
+++ b/components/AnnotationEditor.tsx
@@ -158,7 +158,7 @@ export default function AnnotationEditor({
       <div className="rounded-lg max-w-6xl w-full max-h-[90vh] flex flex-col" style={{ background: 'var(--gx-bg-alt)', boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.5)' }}>
         {/* Header */}
         <div className="p-4 flex justify-between items-center" style={{ borderBottom: '1px solid var(--gx-border)' }}>
-          <h2 className="text-xl font-bold" style={{ color: 'var(--gx-text-bright)' }}>
+          <h2 className="text-xl font-bold" style={{ color: 'var(--gx-text)' }}>
             Annotations for {ringName}
           </h2>
           <button

--- a/components/ConsoleLog.tsx
+++ b/components/ConsoleLog.tsx
@@ -29,7 +29,7 @@ export default function ConsoleLog({ logs, progress }: ConsoleLogProps) {
       {progress && progress.step !== 'idle' && progress.step !== 'Complete!' && (
         <div className="mb-4 pb-4" style={{ borderBottom: '1px solid var(--gx-border)' }}>
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium" style={{ color: 'var(--gx-text-bright)' }}>{progress.step}</span>
+            <span className="text-sm font-medium" style={{ color: 'var(--gx-text)' }}>{progress.step}</span>
             <span className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>{progress.percent}%</span>
           </div>
           <div className="progress-bg">
@@ -52,7 +52,7 @@ export default function ConsoleLog({ logs, progress }: ConsoleLogProps) {
           >
             {isOpen ? '\u25BC' : '\u25B6'}
           </button>
-          <h3 className="font-semibold" style={{ color: 'var(--gx-text-bright)' }}>Debug Console</h3>
+          <h3 className="font-semibold" style={{ color: 'var(--gx-text)' }}>Debug Console</h3>
           <span className="text-xs" style={{ color: 'var(--gx-text-muted)' }}>({logs.length} messages)</span>
         </div>
         <button

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -75,7 +75,7 @@ export default function FileUpload({
         {queryFiles.length > 0 && (
           <div className="mt-2 space-y-1">
             {queryFiles.map((file, index) => (
-              <div key={index} className="flex items-center justify-between text-sm p-2 rounded-lg" style={{ background: 'var(--gx-bg-elevated)', border: '1px solid var(--gx-border)' }}>
+              <div key={index} className="flex items-center justify-between text-sm p-2 rounded-lg" style={{ background: 'var(--gx-surface)', border: '1px solid var(--gx-border)' }}>
                 <span className="truncate" style={{ color: 'var(--gx-text)' }}>{file.name}</span>
                 <button
                   onClick={() => removeQueryFile(index)}

--- a/components/ImageProperties.tsx
+++ b/components/ImageProperties.tsx
@@ -51,7 +51,7 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
           >
             {isOpen ? '\u25BC' : '\u25B6'}
           </button>
-          <h3 className="font-semibold" style={{ color: 'var(--gx-text-bright)' }}>Image Properties</h3>
+          <h3 className="font-semibold" style={{ color: 'var(--gx-text)' }}>Image Properties</h3>
         </div>
       </div>
 
@@ -59,7 +59,7 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
         <div className="space-y-4">
           {/* Ring Dimensions */}
           <div className="space-y-3">
-            <h4 className="text-sm font-semibold pb-1" style={{ color: 'var(--gx-text-bright)', borderBottom: '1px solid var(--gx-border)' }}>
+            <h4 className="text-sm font-semibold pb-1" style={{ color: 'var(--gx-text)', borderBottom: '1px solid var(--gx-border)' }}>
               Ring Dimensions
             </h4>
 
@@ -132,7 +132,7 @@ export default function ImageProperties({ config, onChange }: ImagePropertiesPro
 
           {/* Font Sizes */}
           <div className="space-y-3">
-            <h4 className="text-sm font-semibold pb-1" style={{ color: 'var(--gx-text-bright)', borderBottom: '1px solid var(--gx-border)' }}>
+            <h4 className="text-sm font-semibold pb-1" style={{ color: 'var(--gx-text)', borderBottom: '1px solid var(--gx-border)' }}>
               Font Sizes
             </h4>
 

--- a/components/ProgressPanel.tsx
+++ b/components/ProgressPanel.tsx
@@ -10,7 +10,7 @@ export default function ProgressPanel({ progress }: ProgressPanelProps) {
   return (
     <div className="card animate-fade-in">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium" style={{ color: 'var(--gx-text-bright)' }}>{progress.step}</span>
+        <span className="text-sm font-medium" style={{ color: 'var(--gx-text)' }}>{progress.step}</span>
         <span className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>{progress.percent}%</span>
       </div>
       <div className="progress-bg">

--- a/components/RingConfiguration.tsx
+++ b/components/RingConfiguration.tsx
@@ -83,7 +83,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
   return (
     <div className="space-y-4">
       <div className="flex justify-between items-center">
-        <h3 className="text-sm font-semibold" style={{ color: 'var(--gx-text-bright)' }}>Ring Configuration</h3>
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--gx-text)' }}>Ring Configuration</h3>
         <button
           type="button"
           onClick={addNewRing}
@@ -105,7 +105,7 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations }
           <div
             key={ring.id}
             className="rounded-lg p-4"
-            style={{ border: '1px solid var(--gx-border)', background: 'var(--gx-bg-elevated)' }}
+            style={{ border: '1px solid var(--gx-border)', background: 'var(--gx-surface)' }}
           >
             <div className="flex items-start justify-between mb-3">
               <div className="flex items-center gap-2 flex-1">

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -5,11 +5,11 @@ import { useEffect, useState } from 'react';
 type Theme = 'dark' | 'light';
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>('dark');
+  const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
     const saved = localStorage.getItem('gx-theme') as Theme | null;
-    const current = saved || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    const current = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     setTheme(current);
     document.documentElement.setAttribute('data-theme', current);
   }, []);
@@ -26,7 +26,7 @@ export default function ThemeToggle() {
         onClick={() => applyTheme('dark')}
         className={`px-3 py-1.5 transition-colors ${
           theme === 'dark'
-            ? 'bg-gx-accent text-[#0F172A]'
+            ? 'bg-gx-accent text-gx-text-inverted'
             : 'text-gx-text-muted hover:text-gx-text'
         }`}
         aria-label="Dark theme"
@@ -39,7 +39,7 @@ export default function ThemeToggle() {
         onClick={() => applyTheme('light')}
         className={`px-3 py-1.5 transition-colors ${
           theme === 'light'
-            ? 'bg-gx-accent text-[#0F172A]'
+            ? 'bg-gx-accent text-gx-text-inverted'
             : 'text-gx-text-muted hover:text-gx-text'
         }`}
         aria-label="Light theme"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,10 +13,13 @@ const config: Config = {
         gx: {
           bg: 'var(--gx-bg)',
           'bg-alt': 'var(--gx-bg-alt)',
-          'bg-elevated': 'var(--gx-bg-elevated)',
+          surface: 'var(--gx-surface)',
+          'surface-hover': 'var(--gx-surface-hover)',
+          'bg-elevated': 'var(--gx-bg-elevated)', /* backward compat alias for surface */
           text: 'var(--gx-text)',
           'text-muted': 'var(--gx-text-muted)',
-          'text-bright': 'var(--gx-text-bright)',
+          'text-bright': 'var(--gx-text-bright)', /* backward compat */
+          'text-inverted': 'var(--gx-text-inverted)',
           border: 'var(--gx-border)',
           accent: 'var(--gx-accent)',
           'accent-hover': 'var(--gx-accent-hover)',


### PR DESCRIPTION
## Summary
- Switches `globals.css` from dark-first to **light-first** `:root` with `[data-theme="dark"]` override, matching the ronaQC canonical design system
- Adds new tokens: `--gx-surface`, `--gx-surface-hover`, `--gx-text-inverted`
- Updates `tailwind.config.ts` color mappings for the new tokens
- Updates `ThemeToggle.tsx` to default to light mode
- Replaces `--gx-bg-elevated` → `--gx-surface` and `--gx-text-bright` → `--gx-text` across all components

Ref: genomicx/genomicx.github.io#6

## Test plan
- [x] Run `npm run build` — verify no build errors
- [x] Open app in browser — verify light theme displays correctly by default
- [x] Toggle to dark mode — verify colors match ronaQC dark palette
- [x] Check all components (FileUpload, ConsoleLog, ProgressPanel, etc.) render correctly in both themes
- [x] Verify theme preference persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)