### PR TITLE
User feedback: panel layout, HEX colour input, annotation fixes, identity tooltip

### DIFF
--- a/components/AnnotationEditor.tsx
+++ b/components/AnnotationEditor.tsx
@@ -1,11 +1,12 @@
 
 
+
 import { useState, useRef, useCallback } from 'react';
 import { HotTable } from '@handsontable/react';
 import Handsontable from 'handsontable';
 import { registerAllModules } from 'handsontable/registry';
 import 'handsontable/dist/handsontable.full.min.css';
-import type { Annotation } from '@/lib/types';
+import type { Annotation, AnnotationShape } from '@/lib/types';
 import { parseAnnotationFile, exportAnnotationsToTSV } from '@/lib/annotationParser';
 import toast from 'react-hot-toast';
 
@@ -22,6 +23,41 @@ interface AnnotationEditorProps {
   onClose: () => void;
 }
 
+/** Row shape used internally by Handsontable. */
+interface TableRow {
+  start: number;
+  end: number;
+  label: string;
+  shape: string;
+  color: string;
+}
+
+/** Convert Annotation[] to the flat row objects Handsontable works with. */
+function toTableData(anns: Annotation[]): TableRow[] {
+  return anns.map(a => ({
+    start: a.start,
+    end: a.end,
+    label: a.label,
+    shape: a.shape,
+    color: a.color || '#666666',
+  }));
+}
+
+/** Read Handsontable's current data back into Annotation objects. */
+function readHotData(hot: Handsontable, existingIds: string[]): Annotation[] {
+  const src = hot.getSourceData() as TableRow[];
+  return src
+    .filter(r => r && (r.label || r.start || r.end)) // skip completely empty spare rows
+    .map((r, i) => ({
+      id: existingIds[i] || `ann-${Date.now()}-${i}`,
+      start: Number(r.start) || 1,
+      end: Number(r.end) || 1,
+      label: r.label || '',
+      shape: (r.shape || 'block') as AnnotationShape,
+      color: r.color || '#666666',
+    }));
+}
+
 export default function AnnotationEditor({
   ringId,
   ringName,
@@ -31,11 +67,39 @@ export default function AnnotationEditor({
   onAnnotationsChange,
   onClose
 }: AnnotationEditorProps) {
-  const [localAnnotations, setLocalAnnotations] = useState<Annotation[]>([...annotations]);
+  // Annotation IDs are kept in sync so we can preserve identity across edits
+  const idsRef = useRef<string[]>(annotations.map(a => a.id));
+
+  // The source-of-truth data array is held in a ref so Handsontable can
+  // mutate it directly without React re-renders overwriting cell edits.
+  const tableDataRef = useRef<TableRow[]>(toTableData(annotations));
+
+  // Counter displayed in the toolbar (updated on sync)
+  const [count, setCount] = useState(annotations.length);
+
   const hotRef = useRef<Handsontable | null>(null);
   const [showGenbankImport, setShowGenbankImport] = useState(false);
   const [gbFeatureType, setGbFeatureType] = useState('CDS');
   const [gbTextFilter, setGbTextFilter] = useState('');
+
+  /** Push new data into Handsontable without a full re-render. */
+  const loadDataIntoHot = useCallback((anns: Annotation[]) => {
+    const rows = toTableData(anns);
+    tableDataRef.current = rows;
+    idsRef.current = anns.map(a => a.id);
+    setCount(anns.length);
+    const hot = hotRef.current;
+    if (hot && !hot.isDestroyed) {
+      hot.loadData(rows);
+    }
+  }, []);
+
+  /** Read current table state back into Annotation objects. */
+  const readAnnotations = useCallback((): Annotation[] => {
+    const hot = hotRef.current;
+    if (!hot || hot.isDestroyed) return [];
+    return readHotData(hot, idsRef.current);
+  }, []);
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -60,7 +124,8 @@ export default function AnnotationEditor({
         ...a,
         color: a.color === '#666666' ? ringColor : a.color
       }));
-      setLocalAnnotations([...localAnnotations, ...coloured]);
+      const current = readAnnotations();
+      loadDataIntoHot([...current, ...coloured]);
       toast.success(`Loaded ${result.annotations.length} annotation(s)`);
     } catch (error) {
       toast.error('Failed to parse annotation file');
@@ -72,15 +137,16 @@ export default function AnnotationEditor({
   };
 
   const handleAddNew = () => {
+    const current = readAnnotations();
     const newAnnotation: Annotation = {
       id: `ann-${Date.now()}`,
       start: 1,
       end: Math.min(1000, referenceLength),
-      label: `Annotation ${localAnnotations.length + 1}`,
+      label: `Annotation ${current.length + 1}`,
       shape: 'block',
       color: ringColor
     };
-    setLocalAnnotations([...localAnnotations, newAnnotation]);
+    loadDataIntoHot([...current, newAnnotation]);
     toast.success('Added new annotation');
   };
 
@@ -102,20 +168,27 @@ export default function AnnotationEditor({
       }
     });
 
-    // Filter out selected rows
-    const newAnnotations = localAnnotations.filter((_, idx) => !rowsToDelete.has(idx));
-    setLocalAnnotations(newAnnotations);
+    const current = readAnnotations();
+    const remaining = current.filter((_, idx) => !rowsToDelete.has(idx));
+    loadDataIntoHot(remaining);
     toast.success(`Deleted ${rowsToDelete.size} annotation(s)`);
   };
 
+  const handleReset = () => {
+    loadDataIntoHot([]);
+    toast.success('All annotations cleared');
+  };
+
   const handleSave = () => {
-    onAnnotationsChange(ringId, localAnnotations);
+    const current = readAnnotations();
+    onAnnotationsChange(ringId, current);
     toast.success('Annotations updated');
     onClose();
   };
 
   const handleExport = () => {
-    const tsv = exportAnnotationsToTSV(localAnnotations);
+    const current = readAnnotations();
+    const tsv = exportAnnotationsToTSV(current);
     const blob = new Blob([tsv], { type: 'text/tab-separated-values' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -142,7 +215,8 @@ export default function AnnotationEditor({
 
       // Use ring colour for GenBank features (they default to #000000)
       const coloured = features.map(f => ({ ...f, color: ringColor }));
-      setLocalAnnotations([...localAnnotations, ...coloured]);
+      const current = readAnnotations();
+      loadDataIntoHot([...current, ...coloured]);
       if (features.length > 200) {
         toast.success(`Imported ${features.length} features. Labels auto-disabled (too many).`);
       } else {
@@ -156,42 +230,39 @@ export default function AnnotationEditor({
     e.target.value = '';
   };
 
-  // Convert annotations to table data
-  const data = localAnnotations.map(ann => ({
-    start: ann.start,
-    end: ann.end,
-    label: ann.label,
-    shape: ann.shape,
-    color: ann.color || '#666666'
-  }));
+  // Keep the count in sync when Handsontable rows change via context menu or paste
+  const syncCount = useCallback(() => {
+    const hot = hotRef.current;
+    if (!hot || hot.isDestroyed) return;
+    const src = hot.getSourceData() as TableRow[];
+    const realRows = src.filter(r => r && (r.label || r.start || r.end)).length;
+    setCount(realRows);
+  }, []);
 
-  // Handle data changes from Handsontable
-  const afterChange = useCallback((changes: Handsontable.CellChange[] | null) => {
-    if (!changes) return;
+  // afterChange: update count (Handsontable handles its own data in uncontrolled mode)
+  const afterChange = useCallback((_changes: Handsontable.CellChange[] | null, source: string) => {
+    if (source === 'loadData') return; // ignore initial load
+    syncCount();
+  }, [syncCount]);
 
-    const newAnnotations = [...localAnnotations];
-    changes.forEach(([row, prop, oldValue, newValue]) => {
-      if (oldValue === newValue) return;
+  // afterRemoveRow / afterCreateRow: keep count and IDs in sync
+  const afterRemoveRow = useCallback(() => {
+    syncCount();
+    // Rebuild IDs from current hot data length
+    const hot = hotRef.current;
+    if (hot && !hot.isDestroyed) {
+      const src = hot.getSourceData() as TableRow[];
+      idsRef.current = src.map((_, i) => idsRef.current[i] || `ann-${Date.now()}-${i}`);
+    }
+  }, [syncCount]);
 
-      const ann = newAnnotations[row];
-      if (!ann) return;
+  const afterCreateRow = useCallback(() => {
+    syncCount();
+  }, [syncCount]);
 
-      if (prop === 'start' || prop === 'end') {
-        const num = parseInt(String(newValue), 10);
-        if (!isNaN(num)) {
-          ann[prop] = Math.max(1, Math.min(num, referenceLength));
-        }
-      } else if (prop === 'label') {
-        ann.label = String(newValue);
-      } else if (prop === 'shape') {
-        ann.shape = newValue as Annotation['shape'];
-      } else if (prop === 'color') {
-        ann.color = String(newValue);
-      }
-    });
-
-    setLocalAnnotations(newAnnotations);
-  }, [localAnnotations, referenceLength]);
+  const afterPaste = useCallback(() => {
+    syncCount();
+  }, [syncCount]);
 
   return (
     <div className="fixed inset-0 flex items-center justify-center z-50 p-4" style={{ background: 'rgba(0, 0, 0, 0.6)' }}>
@@ -236,8 +307,15 @@ export default function AnnotationEditor({
             Delete Selected
           </button>
           <button
+            onClick={handleReset}
+            className="btn-secondary text-sm"
+            style={{ borderColor: 'var(--gx-error)', color: 'var(--gx-error)' }}
+          >
+            Reset All
+          </button>
+          <button
             onClick={handleExport}
-            disabled={localAnnotations.length === 0}
+            disabled={count === 0}
             className="btn-secondary text-sm disabled:opacity-50"
           >
             Export TSV
@@ -249,7 +327,7 @@ export default function AnnotationEditor({
             Import GenBank Features
           </button>
           <div className="ml-auto text-sm self-center" style={{ color: 'var(--gx-text-muted)' }}>
-            {localAnnotations.length} annotation(s) | Reference: {referenceLength.toLocaleString()} bp
+            {count} annotation(s) | Reference: {referenceLength.toLocaleString()} bp
           </div>
         </div>
 
@@ -292,12 +370,12 @@ export default function AnnotationEditor({
           </div>
         )}
 
-        {/* Spreadsheet */}
+        {/* Spreadsheet — uncontrolled mode: data is passed once via ref, not re-rendered */}
         <div className="flex-1 overflow-hidden p-4" style={{ minHeight: '400px' }}>
           <HotTable
             ref={(ref) => { hotRef.current = ref?.hotInstance || null; }}
-            data={data}
-            colHeaders={['Start', 'End', 'Label', 'Shape', 'Color']}
+            data={tableDataRef.current}
+            colHeaders={['Start', 'End', 'Label', 'Shape', 'Colour']}
             columns={[
               { data: 'start', type: 'numeric' },
               { data: 'end', type: 'numeric' },
@@ -314,7 +392,10 @@ export default function AnnotationEditor({
             height={450}
             licenseKey="non-commercial-and-evaluation"
             afterChange={afterChange}
-            contextMenu={true}
+            afterRemoveRow={afterRemoveRow}
+            afterCreateRow={afterCreateRow}
+            afterPaste={afterPaste}
+            contextMenu={['row_above', 'row_below', 'remove_row', '---------', 'copy', 'cut']}
             manualRowResize={true}
             manualColumnResize={true}
             stretchH="all"

--- a/components/RingConfiguration.tsx
+++ b/components/RingConfiguration.tsx
@@ -1,6 +1,45 @@
 
 
+import { useState } from 'react';
 import type { RingConfig, RingData } from '@/lib/types';
+
+/** Small controlled hex input that syncs with external colour state on blur / valid input. */
+function HexInput({ value, onChange }: { value: string; onChange: (hex: string) => void }) {
+  const [local, setLocal] = useState(value);
+  const [focused, setFocused] = useState(false);
+
+  // Sync from parent when not focused (e.g. colour picker changes)
+  const displayed = focused ? local : value;
+
+  return (
+    <input
+      type="text"
+      value={displayed}
+      onChange={(e) => {
+        const v = e.target.value;
+        setLocal(v);
+        if (/^#[0-9a-fA-F]{6}$/.test(v)) {
+          onChange(v.toLowerCase());
+        }
+      }}
+      onFocus={() => { setLocal(value); setFocused(true); }}
+      onBlur={(e) => {
+        setFocused(false);
+        let v = e.target.value.trim();
+        if (!v.startsWith('#')) v = '#' + v;
+        if (/^#[0-9a-fA-F]{6}$/.test(v)) {
+          onChange(v.toLowerCase());
+        }
+        // Reset local to current canonical value
+        setLocal(value);
+      }}
+      className="input-field text-xs font-mono w-20 flex-shrink-0"
+      placeholder="#000000"
+      maxLength={7}
+      title="Hex colour code"
+    />
+  );
+}
 
 interface RingConfigurationProps {
   rings: RingConfig[];
@@ -124,9 +163,13 @@ export default function RingConfiguration({ rings, setRings, onEditAnnotations, 
                   type="color"
                   value={ring.color}
                   onChange={(e) => updateRing(ring.id, { color: e.target.value })}
-                  className="w-10 h-8 rounded cursor-pointer border-0 p-0"
+                  className="w-8 h-8 rounded cursor-pointer border-0 p-0 flex-shrink-0"
                   style={{ border: '2px solid var(--gx-border)' }}
-                  title="Ring color"
+                  title="Ring colour"
+                />
+                <HexInput
+                  value={ring.color}
+                  onChange={(hex) => updateRing(ring.id, { color: hex })}
                 />
               </div>
               <button

--- a/components/StatisticsPanel.tsx
+++ b/components/StatisticsPanel.tsx
@@ -1,7 +1,36 @@
 
 
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import type { CircularPlotData } from '@/lib/types';
+
+/** Inline info icon that shows a tooltip on hover/click. */
+function InfoTip({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <span className="relative inline-block ml-1 align-middle">
+      <button
+        type="button"
+        className="inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold leading-none cursor-help"
+        style={{ background: 'var(--gx-border)', color: 'var(--gx-text-muted)' }}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onClick={() => setOpen(v => !v)}
+        aria-label="More information"
+      >
+        ?
+      </button>
+      {open && (
+        <span
+          className="absolute z-20 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-2 rounded text-xs leading-relaxed shadow-lg"
+          style={{ background: 'var(--gx-surface)', color: 'var(--gx-text)', border: '1px solid var(--gx-border)' }}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}
 
 interface StatisticsPanelProps {
   plotData: CircularPlotData;
@@ -38,6 +67,7 @@ export default function StatisticsPanel({ plotData }: StatisticsPanelProps) {
                   <div className="text-sm" style={{ color: 'var(--gx-text-muted)' }}>
                     Coverage: {ring.statistics.genomeCoverage.toFixed(1)}% |
                     Avg Identity: {ring.statistics.meanIdentity.toFixed(1)}%
+                    <InfoTip text="Alignment-length-weighted mean of BLAST percent identity across all hits that pass the minimum identity and length filters. Each hit's identity is weighted by the number of reference bases it covers." />
                   </div>
                 </div>
                 <div className="flex items-center gap-3">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -58,14 +58,14 @@ export default function Home() {
 
         <main className="flex-1 py-8">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
-              <div className="lg:col-span-1 space-y-6 animate-fade-in">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8 lg:items-start">
+              <div className="lg:col-span-1 space-y-6 animate-fade-in lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto lg:pr-2">
                 <ReferenceInput referenceFile={referenceFile} onFileChange={handleReferenceFileChange} />
                 <RingsPanel rings={rings} setRings={setRings} onEditAnnotations={handleOpenAnnotationEditor} ringDataList={plotData?.rings} />
                 <ControlPanel params={params} setParams={setParams} isProcessing={isProcessing} referenceFile={referenceFile} rings={rings} plotData={plotData} onRun={handleRun} />
               </div>
 
-              <div className="lg:col-span-2 animate-slide-up">
+              <div className="lg:col-span-2 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:overflow-y-auto animate-slide-up">
                 <ImagePropertiesPanel imageProperties={imageProperties} onChange={setImageProperties} />
 
                 <div className={`card ${plotExpanded ? 'fixed inset-0 z-50 flex flex-col' : ''}`} style={plotExpanded ? { background: 'var(--gx-bg-alt)', borderRadius: 0 } : undefined}>


### PR DESCRIPTION
## Summary

Fixes four tractable issues from user feedback testing. Each fix is a separate commit.

| Issue | Change | Status |
|-------|--------|--------|
| #8 - Settings and output panels cannot be viewed simultaneously | Left settings column scrolls independently; right output column uses `sticky` positioning on lg+ screens so both remain visible | Fixed |
| #9 - Add HEX colour code input alongside colour picker | Added a text input next to each ring colour picker that accepts/displays hex values, synced bidirectionally with the colour swatch | Fixed |
| #11 - Statistics panel "average identity" has no explanation | Added an info icon with hover tooltip explaining the alignment-length-weighted mean calculation | Fixed |
| #12 - Annotation spreadsheet: cannot delete rows, edit cells, or paste from Excel | Switched Handsontable from controlled to uncontrolled mode, eliminating the React re-render overwrite conflict. Context menu now includes row insert/delete. Added "Reset All" button | Fixed |
| #10 - File read permission error | Needs deeper root cause investigation | Out of scope |
| #13 - Linear visualisation | Feature request, out of scope for this PR | Out of scope |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 132 unit tests pass (`npm test`)
- [ ] On a standard laptop (1366x768 or 1440x900), verify settings panel scrolls while output/plot stays visible
- [ ] Add a ring, verify hex input appears next to colour picker; type a hex value and confirm swatch updates; pick a colour and confirm hex input updates
- [ ] In Statistics panel, hover the "?" icon next to Avg Identity and verify tooltip appears
- [ ] Open annotation editor, edit a cell inline, verify the edit persists; right-click to delete a row via context menu; paste multi-row data from a spreadsheet; click "Reset All" to clear

Generated with [Claude Code](https://claude.com/claude-code)